### PR TITLE
fixes CharSetBodyGroup

### DIFF
--- a/gamemode/core/sh_commands.lua
+++ b/gamemode/core/sh_commands.lua
@@ -160,7 +160,7 @@ ix.command.Add("CharSetBodygroup", {
 				value = nil
 			end
 
-			local groups = target:GetChar():GetData("groups", {})
+			local groups = target:GetData("groups", {})
 				groups[index] = value
 			target:SetData("groups", groups)
 			target:GetPlayer():SetBodygroup(index, value or 0)


### PR DESCRIPTION
GetChar() broke the command, guess you don't need it for bodygroups.