### PR TITLE
Allows using PlyTransfer using chat

### DIFF
--- a/gamemode/core/sh_commands.lua
+++ b/gamemode/core/sh_commands.lua
@@ -587,7 +587,7 @@ ix.command.Add("PlyTransfer", {
 	OnRun = function(self, client, target, name)
 		local faction = ix.faction.teams[name]
 
-		if (!name) then
+		if (!faction) then
 			for _, v in pairs(ix.faction.indices) do
 				if (ix.util.StringMatches(L(v.name, client), name)) then
 					faction = v


### PR DESCRIPTION
We went public with an SSTRP Server because why the fuck not and we had this.

```The faction you provided could not be found.
[SERVER] SgtMaj. Mark Gray used command '/PlyTransfer rosser Mobile Infantry Troops'.
The faction you provided could not be found.
[SERVER] SgtMaj. Mark Gray used command '/PlyTransfer rosser Mobile Infantry Troops'.```

We fixed it on our server and it works now, so it is fully tested