### PR TITLE
Fix error upon changing font in config.

### DIFF
--- a/gamemode/config/sh_config.lua
+++ b/gamemode/config/sh_config.lua
@@ -18,8 +18,6 @@ ix.config.Add("maxChars", 5, "The maximum number of characters a player can have
 })
 ix.config.Add("color", Color(75, 119, 190), "The main color theme for the framework.", nil, {category = "appearance"})
 ix.config.Add("font", "Impact", "The font used to display titles.", function(oldValue, newValue)
-	newValue.a = 255
-
 	if (CLIENT) then
 		hook.Run("LoadFonts", newValue, ix.config.Get("genericFont"))
 	end

--- a/gamemode/config/sh_config.lua
+++ b/gamemode/config/sh_config.lua
@@ -16,7 +16,11 @@ ix.config.Add("maxChars", 5, "The maximum number of characters a player can have
 	data = {min = 1, max = 50},
 	category = "characters"
 })
-ix.config.Add("color", Color(75, 119, 190), "The main color theme for the framework.", nil, {category = "appearance"})
+
+ix.config.Add("color", Color(75, 119, 190), "The main color theme for the framework.", function(oldValue, newValue)
+	newValue.a = 255
+end, {category = "appearance"})
+
 ix.config.Add("font", "Impact", "The font used to display titles.", function(oldValue, newValue)
 	if (CLIENT) then
 		hook.Run("LoadFonts", newValue, ix.config.Get("genericFont"))


### PR DESCRIPTION
`newValue` is a string, not a color. I'm guessing this was meant for the color configuration?