### PR TITLE
Close character menu upon pressing tab.

### DIFF
--- a/gamemode/core/derma/cl_character.lua
+++ b/gamemode/core/derma/cl_character.lua
@@ -504,8 +504,8 @@ function PANEL:Init()
 	CreateMainButtons()
 end
 
-function PANEL:Think()
-	if (input.IsKeyDown(KEY_F1) and LocalPlayer():GetChar() and !self.choosing) then
+function PANEL:OnKeyCodePressed(key)
+	if (key == KEY_TAB and LocalPlayer():GetChar() and !self.choosing) then
 		self:Remove()
 	end
 end


### PR DESCRIPTION
The other menus work the same way. This brings the character menu in line with the others.