### PR TITLE
Replace deprecated tooltip calls.

### DIFF
--- a/gamemode/core/derma/cl_business.lua
+++ b/gamemode/core/derma/cl_business.lua
@@ -37,7 +37,7 @@ function PANEL:SetItem(itemTable)
 	self.icon:DockMargin(5, 5, 5, 10)
 	self.icon:InvalidateLayout(true)
 	self.icon:SetModel(itemTable.model, itemTable.skin or 0)
-	self.icon:SetToolTip(
+	self.icon:SetTooltip(
 		Format(ix.config.itemFormat,
 		itemTable.GetName and itemTable:GetName() or L(itemTable.name), itemTable:GetDescription() or "")
 	)
@@ -408,7 +408,7 @@ function PANEL:SetCart(items)
 			slot.icon:SetPos(2, 2)
 			slot.icon:SetSize(32, 32)
 			slot.icon:SetModel(itemTable.model)
-			slot.icon:SetToolTip("")
+			slot.icon:SetTooltip("")
 
 			slot.name = slot:Add("DLabel")
 			slot.name:SetPos(40, 2)

--- a/gamemode/core/derma/cl_character.lua
+++ b/gamemode/core/derma/cl_character.lua
@@ -77,7 +77,7 @@ function PANEL:Init()
 			</body>
 		</html>
 	]], ix.config.Get("logo", "https://static.miraheze.org/nutscriptwiki/2/26/Nutscript.png")))
-	self.icon:SetToolTip(ix.config.Get("logoURL", "https://nutscript.net"))
+	self.icon:SetTooltip(ix.config.Get("logoURL", "https://nutscript.net"))
 
 	self.icon.click = self.icon:Add("DButton")
 	self.icon.click:Dock(FILL)

--- a/gamemode/core/derma/cl_inventory.lua
+++ b/gamemode/core/derma/cl_inventory.lua
@@ -281,9 +281,9 @@ function PANEL:SetInventory(inventory)
 						local newTooltip = hook.Run("OverrideItemTooltip", self, data, item)
 
 						if (newTooltip) then
-							icon:SetToolTip(newTooltip)
+							icon:SetTooltip(newTooltip)
 						else
-							icon:SetToolTip(
+							icon:SetTooltip(
 								Format(ix.config.itemFormat,
 								item.GetName and item:GetName() or L(item.name), item:GetDescription() or "")
 							)

--- a/gamemode/core/derma/cl_menubutton.lua
+++ b/gamemode/core/derma/cl_menubutton.lua
@@ -15,7 +15,7 @@ local PANEL = {}
 		BaseClass.SetText(self, noTranslation and text:upper() or L(text):upper())
 
 		if (!noTranslation) then
-			self:SetToolTip(L(text.."Tip"))
+			self:SetTooltip(L(text.."Tip"))
 		end
 
 		local w, h = surface.GetTextSize(self:GetText())

--- a/gamemode/core/derma/cl_scoreboard.lua
+++ b/gamemode/core/derma/cl_scoreboard.lua
@@ -122,7 +122,7 @@ function PANEL:AddPlayer(client, parent)
 
 		RegisterDermaMenuForClose(menu)
 	end
-	slot.model:SetToolTip(L("sbOptions", client:SteamName()))
+	slot.model:SetTooltip(L("sbOptions", client:SteamName()))
 
 	timer.Simple(0, function()
 		if (!IsValid(slot)) then
@@ -225,7 +225,7 @@ function PANEL:AddPlayer(client, parent)
 
 		if (panel.lastModel != model or panel.lastSkin != skin) then
 			panel.model:SetModel(client:GetModel(), client:GetSkin())
-			panel.model:SetToolTip(L("sbOptions", client:SteamName()))
+			panel.model:SetTooltip(L("sbOptions", client:SteamName()))
 
 			panel.lastModel = model
 			panel.lastSkin = skin

--- a/gamemode/core/derma/cl_shipment.lua
+++ b/gamemode/core/derma/cl_shipment.lua
@@ -30,7 +30,7 @@ local PANEL = {}
 				item.icon:SetPos(2, 2)
 				item.icon:SetSize(32, 32)
 				item.icon:SetModel(itemTable.model)
-				item.icon:SetToolTip(itemTable:GetDescription())
+				item.icon:SetTooltip(itemTable:GetDescription())
 
 				item.quantity = item.icon:Add("DLabel")
 				item.quantity:SetSize(32, 32)

--- a/gamemode/core/libs/sh_item.lua
+++ b/gamemode/core/libs/sh_item.lua
@@ -463,7 +463,7 @@ do
 					local icon = panel.panels[id]
 
 					if (icon) then
-						icon:SetToolTip(
+						icon:SetTooltip(
 							Format(ix.config.itemFormat,
 							item.GetName and item:GetName() or L(item.name), item:GetDescription() or "")
 						)
@@ -501,7 +501,7 @@ do
 						local icon = panel:AddIcon(item.model or "models/props_junk/popcan01a.mdl", x, y, item.width, item.height)
 
 						if (IsValid(icon)) then
-							icon:SetToolTip(
+							icon:SetTooltip(
 								Format(ix.config.itemFormat,
 								item.GetName and item:GetName() or L(item.name), item:GetDescription() or "")
 							)

--- a/gamemode/core/sh_config.lua
+++ b/gamemode/core/sh_config.lua
@@ -260,7 +260,7 @@ if (CLIENT) then
 						local row = properties:CreateRow(category, k)
 						row:Setup(form, v.data and v.data.data or {})
 						row:SetValue(value)
-						row:SetToolTip(v.description)
+						row:SetTooltip(v.description)
 						row.DataChanged = function(this, newValue)
 							timer.Create("ixCfgSend"..k, delay, 1, function()
 								if (IsValid(row)) then


### PR DESCRIPTION
`SetToolTip` is deprecated. This changes the calls to `SetTooltip`