### PR TITLE
Support localized faction names

### DIFF
--- a/gamemode/core/derma/cl_charcreate.lua
+++ b/gamemode/core/derma/cl_charcreate.lua
@@ -341,7 +341,7 @@ function PANEL:Populate()
 			if (ix.faction.HasWhitelist(v.index)) then
 				local button = self.factionButtonsPanel:Add("ixMenuSelectionButton")
 				button:SetBackgroundColor(v.color or color_white)
-				button:SetText(v.name:upper())
+				button:SetText(L(v.name):upper())
 				button:Dock(BOTTOM)
 				button:SetButtonList(self.factionButtons)
 				button.faction = v.index

--- a/gamemode/core/derma/cl_information.lua
+++ b/gamemode/core/derma/cl_information.lua
@@ -242,7 +242,7 @@ function PANEL:Update(character)
 
 	if (self.faction) then
 		self.faction:SetLabelText(L("faction"))
-		self.faction:SetText(faction.name)
+		self.faction:SetText(L(faction.name))
 		self.faction:SizeToContents()
 	end
 

--- a/gamemode/core/derma/cl_scoreboard.lua
+++ b/gamemode/core/derma/cl_scoreboard.lua
@@ -263,7 +263,7 @@ end
 
 function PANEL:SetFaction(faction)
 	self:SetColor(faction.color)
-	self:SetText(faction.name)
+	self:SetText(L(faction.name))
 
 	self.faction = faction
 end


### PR DESCRIPTION
On the whitelist and unwhitelist commands, as of https://github.com/NebulousCloud/helix/blob/ed4472de2b85e4017bb79908f5ff9f048d2ba8ec/gamemode/core/sh_commands.lua#L454
matches the faction with it's localized name (aka, using the L function to check if it's on the language files, or if not return the default name).
But, this is not being done on the clientside menus (like the scoreboard, character creation/selection menu) and the information menu.