### PR TITLE
Fixed AddSubMenu DMenuOption not having the right color

### DIFF
--- a/gamemode/core/derma/cl_overrides.lua
+++ b/gamemode/core/derma/cl_overrides.lua
@@ -103,6 +103,16 @@ OverridePanel("DMenu", function()
 		return panel
 	end
 
+	Override("AddSubMenu")
+	function PANEL:AddSubMenu(...)
+		local menu, panel = self:ixAddSubMenu(...)
+
+		panel:SetTextColor(derma.GetColor("MenuLabel", self, color_black))
+		panel:SetTextInset(6, 0) -- there is no icon functionality in DComboBoxes
+
+		return menu, panel
+	end
+
 	Override("Open")
 	function PANEL:Open(x, y, bSkipAnimation, ownerPanel)
 		self.ixX, self.ixY, self.ixOwnerPanel = x, y, ownerPanel


### PR DESCRIPTION
Just what the name says, when a DermaMenu is created and it has a sub DMenu, the label doesn't get colored white and appears black.