### PR TITLE
Set inventory_type to 150 length to accomodate longer path names.

### DIFF
--- a/gamemode/core/libs/sv_database.lua
+++ b/gamemode/core/libs/sv_database.lua
@@ -84,7 +84,7 @@ function ix.db.LoadTables()
 	query = mysql:Create("ix_inventories")
 		query:Create("inventory_id", "INT(11) UNSIGNED NOT NULL AUTO_INCREMENT")
 		query:Create("character_id", "INT(11) UNSIGNED NOT NULL")
-		query:Create("inventory_type", "VARCHAR(24) DEFAULT NULL")
+		query:Create("inventory_type", "VARCHAR(150) DEFAULT NULL")
 		query:PrimaryKey("inventory_id")
 	query:Execute()
 


### PR DESCRIPTION
Should fix using the inventory of container inventories of props with longer path names on older mysql versions.