### PR TITLE
Fix entities with non-existent items

### DIFF
--- a/entities/entities/ix_item.lua
+++ b/entities/entities/ix_item.lua
@@ -148,6 +148,10 @@ if (SERVER) then
 	function ENT:Think()
 		local itemTable = self:GetItemTable()
 
+		if (!itemTable) then
+			self:Remove()
+		end
+
 		if (itemTable.Think) then
 			itemTable:Think(self)
 		end


### PR DESCRIPTION
Fixes this weird error:
```
[ERROR] gamemodes/helix/entities/entities/ix_item.lua:151: attempt to index local 'itemTable' (a nil value)
1. unknown - gamemodes/helix/entities/entities/ix_item.lua:151
```