### PR TITLE
Added prop_physics derivatives to allowedHoldableClasses

### DIFF
--- a/entities/weapons/ix_hands.lua
+++ b/entities/weapons/ix_hands.lua
@@ -49,6 +49,8 @@ SWEP.maxHoldStress = 4000 -- how much stress the held object can undergo before 
 SWEP.allowedHoldableClasses = {
 	["ix_item"] = true,
 	["prop_physics"] = true,
+	["prop_physics_override"] = true,
+	["prop_physics_multiplayer"] = true,
 	["prop_ragdoll"] = true
 }
 


### PR DESCRIPTION
prop_physics_override and prop_physics_multiplayer are essentially identical to normal prop_physics, meaning the player should logically be able to grab them.