### PR TITLE
Fixed observer entering vehicle bug

### DIFF
--- a/plugins/observer.lua
+++ b/plugins/observer.lua
@@ -183,7 +183,16 @@ else
 		end
 	end
 
-	function PLUGIN:PlayerLeaveVehicle(client)
-		client:GodDisable()
+	function PLUGIN:PlayerEnteredVehicle(client)
+		if client.ixObsData then
+			client.ixObsData = nil
+			client:SetNoDraw(false)
+			client:SetNotSolid(false)
+			client:DrawWorldModel(true)
+			client:DrawShadow(true)
+			client:GodDisable()
+			client:SetNoTarget(false)
+			hook.Run("OnPlayerObserve", client, false)
+		end
 	end
 end

--- a/plugins/observer.lua
+++ b/plugins/observer.lua
@@ -182,4 +182,8 @@ else
 			ix.log.Add(client, "observerExit")
 		end
 	end
+
+	function PLUGIN:PlayerLeaveVehicle(client)
+		client:GodDisable()
+	end
 end


### PR DESCRIPTION
Sometimes, admins go in observer mode and don't want to be sent back to the place where they enabled noclip.

So they spawn a vehicle, enter it and leave it, so they can walk etc.

The issue is god mode (and other stuff) was not being disabled when leaving the vehicle.