### PR TITLE
Alternative typing text angle

### DIFF
--- a/gamemode/languages/sh_english.lua
+++ b/gamemode/languages/sh_english.lua
@@ -368,6 +368,8 @@ LANGUAGE = {
 	optdChatFontScale = "How much bigger or smaller the chat font should be.",
 	optChatOutline = "Outline chat text",
 	optdChatOutline = "Draws an outline around the chat text, rather than a drop shadow. Enable this if you are having trouble reading text.",
+	optCorrectAngleTypingText = "Draws the typing text with an ajusted angle.",
+	optdCorrectAngleTypingText = "Calculates the correct angle of the text drawn over the heads of the players.",
 
 	cmdRoll = "Rolls a number between 0 and the specified number.",
 	cmdPM = "Sends a private message to someone.",

--- a/gamemode/languages/sh_french.lua
+++ b/gamemode/languages/sh_french.lua
@@ -365,6 +365,8 @@ LANGUAGE = {
 	optdChatFontScale = "A quelle taille doit être la police de discussion.",
 	optChatOutline = "Décrire le texte du chat",
 	optdChatOutline = "Affiche un contour autour du texte de la discussion plutôt qu’une ombre. Activez cette option si vous rencontrez des difficultés pour lire du texte.",
+	optCorrectAngleTypingText = "Affiche le texte d'écriture avec un angle ajusté.",
+	optdCorrectAngleTypingText = "Calcul le vrai angle du texte affiché au dessus de la tête des joueurs.",
 
 	cmdRoll = "Rolls un nombre entre 0 et le nombre spécifié",
 	cmdPM = "Envoie un message privé à quelqu'un.",

--- a/plugins/typing.lua
+++ b/plugins/typing.lua
@@ -150,24 +150,37 @@ if (CLIENT) then
 			fraction = 1
 		end
 
-		local angle = EyeAngles()
-		angle:RotateAroundAxis(angle:Forward(), 90)
-		angle:RotateAroundAxis(angle:Right(), 90)
+		if ix.option.Get("correctAngleTypingText", true) then
+			local pos = LocalPlayer():GetPos()
+			local target = self:GetTypingIndicatorPosition(client)
+			local targetX = target.x
+			local targetY = target.y
+			local Y = math.fmod(math.atan2(pos.y - targetY, pos.x - targetX), math.pi * 2)
+			local angle_2 = Angle(0, math.deg(Y), 0)
+			angle_2:RotateAroundAxis(angle_2:Forward(), 90)
+			angle_2:RotateAroundAxis(angle_2:Right(), -90)
 
-		cam.Start3D2D(self:GetTypingIndicatorPosition(client), Angle(0, angle.y, 90), 0.05)
-			surface.SetFont("ixTypingIndicator")
+			cam.Start3D2D(target, angle_2, 0.05)
+		else
+			local angle = EyeAngles()
+			angle:RotateAroundAxis(angle:Forward(), 90)
+			angle:RotateAroundAxis(angle:Right(), 90)
 
-			local _, textHeight = surface.GetTextSize(text)
-			local alpha = bAnimation and ((1 - math.min(distance, range) / range) * 255 * fraction) or 255
+			cam.Start3D2D(self:GetTypingIndicatorPosition(client), Angle(0, angle.y, 90), 0.05)
+		end
+				surface.SetFont("ixTypingIndicator")
 
-			draw.SimpleTextOutlined(text, "ixTypingIndicator", 0,
-				-textHeight * 0.5 * fraction,
-				ColorAlpha(textColor, alpha),
-				TEXT_ALIGN_CENTER,
-				TEXT_ALIGN_CENTER, 4,
-				ColorAlpha(shadowColor, alpha)
-			)
-		cam.End3D2D()
+				local _, textHeight = surface.GetTextSize(text)
+				local alpha = bAnimation and ((1 - math.min(distance, range) / range) * 255 * fraction) or 255
+
+				draw.SimpleTextOutlined(text, "ixTypingIndicator", 0,
+					-textHeight * 0.5 * fraction,
+					ColorAlpha(textColor, alpha),
+					TEXT_ALIGN_CENTER,
+					TEXT_ALIGN_CENTER, 4,
+					ColorAlpha(shadowColor, alpha)
+				)
+			cam.End3D2D()
 	end
 
 	net.Receive("ixTypeClass", function()
@@ -208,6 +221,9 @@ if (CLIENT) then
 			end
 		end
 	end)
+	ix.option.Add("correctAngleTypingText", ix.type.bool, false, {
+		category = "performance"
+	})
 else
 	util.AddNetworkString("ixTypeClass")
 


### PR DESCRIPTION
New option allowing to draw the Typing text with an alternative angle

Instead of using playerview.y the text is always looking toward the player.

Video : https://www.youtube.com/watch?v=u_79jtKQ3sM

Disabled by default.

English isn't my first language, so if you got a better idea for the config name or the description, feel free to change it.