### PR TITLE
Vendor panel editor fix

### DIFF
--- a/plugins/vendor/sh_plugin.lua
+++ b/plugins/vendor/sh_plugin.lua
@@ -524,9 +524,9 @@ else
 		local data = net.ReadType()
 
 		if (key == "name") then
-			editor.name:SetText(entity:GetDisplayName())
+			editor.name:SetText(data)
 		elseif (key == "description") then
-			editor.description:SetText(entity:GetDescription())
+			editor.description:SetText(data)
 		elseif (key == "bubble") then
 			editor.bubble.noSend = true
 			editor.bubble:SetValue(data and 1 or 0)


### PR DESCRIPTION
When assigning a new description or name, pressing enter updated the vendor panel but updated the editor panel to the OLD name/desc because the DT method isn't as fast as the net lib.



Player edit name/desc -> send update to server -> server confirm and send back update to clients -> player that edited the name/desc is told to check the new name using the DT method -> dt var is outdated since the server didn't have the time to send it -> the edited name in the vendor editor panel is replaced by the OLD name