### PR TITLE
Fix admin notification to show correct oldname

### DIFF
--- a/gamemode/core/sh_commands.lua
+++ b/gamemode/core/sh_commands.lua
@@ -256,6 +256,13 @@ ix.command.Add("CharSetName", {
 		bit.bor(ix.type.text, ix.type.optional)
 	},
 	OnRun = function(self, client, target, newName)
+
+		for _, v in ipairs(player.GetAll()) do
+			if (self:OnCheckAccess(v) or v == target:GetPlayer()) then
+				v:NotifyLocalized("cChangeName", client:GetName(), target:GetName(), newName)
+			end
+		end
+
 		-- display string request if no name was specified
 		if (newName:len() == 0) then
 			return client:RequestString("@chgName", "@chgNameDesc", function(text)
@@ -265,11 +272,6 @@ ix.command.Add("CharSetName", {
 
 		target:SetName(newName:gsub("#", "#​"))
 
-		for _, v in ipairs(player.GetAll()) do
-			if (self:OnCheckAccess(v) or v == target:GetPlayer()) then
-				v:NotifyLocalized("cChangeName", client:GetName(), target:GetName(), newName)
-			end
-		end
 	end
 })
 

--- a/gamemode/core/sh_commands.lua
+++ b/gamemode/core/sh_commands.lua
@@ -256,7 +256,6 @@ ix.command.Add("CharSetName", {
 		bit.bor(ix.type.text, ix.type.optional)
 	},
 	OnRun = function(self, client, target, newName)
-
 		for _, v in ipairs(player.GetAll()) do
 			if (self:OnCheckAccess(v) or v == target:GetPlayer()) then
 				v:NotifyLocalized("cChangeName", client:GetName(), target:GetName(), newName)
@@ -271,7 +270,6 @@ ix.command.Add("CharSetName", {
 		end
 
 		target:SetName(newName:gsub("#", "#​"))
-
 	end
 })
 


### PR DESCRIPTION
Currently, the text shown to admins shows the new name as both the old and new, placing the broadcast first fixes that issue.

```
C17:RL.YELLOW-2 changed C17:RL.YELLOW-2's name to C17:RL.YELLOW-2.
[SERVER] C17:RL.YELLOW-2 used command '/CharSetName C17:RL.YELLOW-1 C17:RL.YELLOW-2'.
```
This should be
```
C17:RL.YELLOW-1 changed C17:RL.YELLOW-1's name to C17:RL.YELLOW-2.
[SERVER] C17:RL.YELLOW-1 used command '/CharSetName C17:RL.YELLOW-1 C17:RL.YELLOW-2'.
```