### PR TITLE
Fix persistence breaking LoadData chain if entity could not be created.

### DIFF
--- a/plugins/persistence.lua
+++ b/plugins/persistence.lua
@@ -89,24 +89,27 @@ if (SERVER) then
 
 		for _, v in ipairs(entities) do
 			local entity = ents.Create(v.Class)
+
+			if entity then
 				entity:SetPos(v.Pos)
 				entity:SetAngles(v.Angle)
 				entity:SetModel(v.Model)
 				entity:SetSkin(v.Skin)
 				entity:SetColor(v.Color)
 				entity:SetMaterial(v.Material)
-			entity:Spawn()
-			entity:Activate()
+				entity:Spawn()
+				entity:Activate()
 
-			local physicsObject = entity:GetPhysicsObject()
+				local physicsObject = entity:GetPhysicsObject()
 
-			if (IsValid(physicsObject)) then
-				physicsObject:EnableMotion(v.Movable)
+				if (IsValid(physicsObject)) then
+					physicsObject:EnableMotion(v.Movable)
+				end
+
+				self.stored[#self.stored + 1] = entity
+
+				entity:SetNetVar("Persistent", true)
 			end
-
-			self.stored[#self.stored + 1] = entity
-
-			entity:SetNetVar("Persistent", true)
 		end
 	end
 

--- a/plugins/persistence.lua
+++ b/plugins/persistence.lua
@@ -90,7 +90,7 @@ if (SERVER) then
 		for _, v in ipairs(entities) do
 			local entity = ents.Create(v.Class)
 
-			if IsValid(entity) then
+			if (IsValid(entity)) then
 				entity:SetPos(v.Pos)
 				entity:SetAngles(v.Angle)
 				entity:SetModel(v.Model)

--- a/plugins/persistence.lua
+++ b/plugins/persistence.lua
@@ -90,7 +90,7 @@ if (SERVER) then
 		for _, v in ipairs(entities) do
 			local entity = ents.Create(v.Class)
 
-			if entity then
+			if IsValid(entity) then
 				entity:SetPos(v.Pos)
 				entity:SetAngles(v.Angle)
 				entity:SetModel(v.Model)


### PR DESCRIPTION
For example, if you have a persistent entity, and you remove the addon it's from, `ents.Create` would fail and the plugin would run calls on a null entity and break everything.