### PR TITLE
Removed duplicated notification on /charsetname panel

### DIFF
--- a/gamemode/core/sh_commands.lua
+++ b/gamemode/core/sh_commands.lua
@@ -256,7 +256,6 @@ ix.command.Add("CharSetName", {
 		bit.bor(ix.type.text, ix.type.optional)
 	},
 	OnRun = function(self, client, target, newName)
-		
 		-- display string request panel if no name was specified
 		if (newName:len() == 0) then
 			return client:RequestString("@chgName", "@chgNameDesc", function(text)

--- a/gamemode/core/sh_commands.lua
+++ b/gamemode/core/sh_commands.lua
@@ -256,17 +256,18 @@ ix.command.Add("CharSetName", {
 		bit.bor(ix.type.text, ix.type.optional)
 	},
 	OnRun = function(self, client, target, newName)
-		for _, v in ipairs(player.GetAll()) do
-			if (self:OnCheckAccess(v) or v == target:GetPlayer()) then
-				v:NotifyLocalized("cChangeName", client:GetName(), target:GetName(), newName)
-			end
-		end
-
-		-- display string request if no name was specified
+		
+		-- display string request panel if no name was specified
 		if (newName:len() == 0) then
 			return client:RequestString("@chgName", "@chgNameDesc", function(text)
 				ix.command.Run(client, "CharSetName", {target:GetName(), text})
 			end, target:GetName())
+		end
+
+		for _, v in ipairs(player.GetAll()) do
+			if (self:OnCheckAccess(v) or v == target:GetPlayer()) then
+				v:NotifyLocalized("cChangeName", client:GetName(), target:GetName(), newName)
+			end
 		end
 
 		target:SetName(newName:gsub("#", "#​"))


### PR DESCRIPTION
Recursive nature of the client:RequestString() caused the notification to appear twice.

Old:
```
Gary changed Gary's name to .
[SERVER] Gary used command '/CharSetName gary'.
Gary changed Gary's name to Johnny.
[SERVER] Johnny used command '/CharSetName Gary Johnny'.
```

New:
```
[SERVER] Johnny used command '/CharSetName johnny'.
Johnny changed Johnny's name to Jacob.
[SERVER] Jacob used command '/CharSetName Johnny Jacob'.
```