### PR TITLE
Don't reset the bodygroups if it is unwanted @ outfit base

### DIFF
--- a/gamemode/items/base/sh_outfit.lua
+++ b/gamemode/items/base/sh_outfit.lua
@@ -189,7 +189,7 @@ ITEM.functions.Equip = {
 		if (!table.IsEmpty(groups)) then
 			char:SetData("oldGroups" .. item.outfitCategory, groups)
 
-			if (!item.bNoBodygroupReset) then
+			if (!item.bNoResetBodygroup) then
 				client:ResetBodygroups()
 			end
 		end

--- a/gamemode/items/base/sh_outfit.lua
+++ b/gamemode/items/base/sh_outfit.lua
@@ -189,7 +189,9 @@ ITEM.functions.Equip = {
 		if (!table.IsEmpty(groups)) then
 			char:SetData("oldGroups" .. item.outfitCategory, groups)
 
-			client:ResetBodygroups()
+			if (!item.bNoBodygroupReset) then
+				client:ResetBodygroups()
+			end
 		end
 
 		if (item.bodyGroups) then


### PR DESCRIPTION
In the outfit base, when bodygroups are assigned, the previous bodygroups are wiped.
This is sometimes undesirable. This is a simple fix which is backwards-compatible and allows developers more control over this.