### PR TITLE
Added /CharGetFlags command

### DIFF
--- a/gamemode/core/sh_commands.lua
+++ b/gamemode/core/sh_commands.lua
@@ -133,6 +133,24 @@ ix.command.Add("CharTakeFlag", {
 	end
 })
 
+ix.command.Add("CharGetFlags", {
+	description = "@cmdCharGetFlags",
+	privilege = "View Character Flags",
+	superAdminOnly = true,
+	arguments = {
+		ix.type.character
+	},
+	OnRun = function(self, client, target)
+		local format = "%s has flags: %s"
+
+		if (target:GetData() or target:GetData("f") == "") then
+			return string.format(format, target.player:GetName(), "none")
+		else
+			return string.format(format, target.player:GetName(), target:GetData("f"))
+		end
+	end
+})
+
 ix.command.Add("ToggleRaise", {
 	description = "@cmdToggleRaise",
 	OnRun = function(self, client, arguments)

--- a/gamemode/core/sh_commands.lua
+++ b/gamemode/core/sh_commands.lua
@@ -143,13 +143,14 @@ ix.command.Add("CharGetFlags", {
 	OnRun = function(self, client, target)
 		local format = "%s has flags: %s"
 
-		if (target:GetData() or target:GetData("f") == "") then
-			return string.format(format, target.player:GetName(), "none")
-		else
+		if (#target:GetData("f") != 0) then
 			return string.format(format, target.player:GetName(), target:GetData("f"))
+		else
+			return string.format(format, target.player:GetName(), "none")
 		end
 	end
 })
+
 
 ix.command.Add("ToggleRaise", {
 	description = "@cmdToggleRaise",

--- a/gamemode/languages/sh_english.lua
+++ b/gamemode/languages/sh_english.lua
@@ -380,6 +380,7 @@ LANGUAGE = {
 	cmdSetVoicemail = "Sets or removes the auto-reply message when someone sends you a private message.",
 	cmdCharGiveFlag = "Gives the specified flag(s) to someone.",
 	cmdCharTakeFlag = "Removes the specified flag(s) from someone if they have it.",
+	cmdCharGetFlags = "Displays the flag(s) available to someone.",
 	cmdToggleRaise = "Raises or lowers the weapon you're holding.",
 	cmdCharSetModel = "Sets a person's character model.",
 	cmdCharSetSkin = "Sets the skin for a person's character model.",


### PR DESCRIPTION
Currently there is no way to check a character's flags, this command gives simple outputs in the chatbox.

```
/chargetflags jacob
Jacob Sanguia has flags: none
/chargiveflag jacob petr
/chargetflags jacob
Jacob Sanguia has flags: petr

```