### PR TITLE
Add access for admins to check other character's inventory.

### DIFF
--- a/gamemode/core/sh_commands.lua
+++ b/gamemode/core/sh_commands.lua
@@ -790,7 +790,9 @@ ix.command.Add("CheckInventory", {
 	adminOnly = true,
 	arguments = ix.type.character,
 	OnRun = function(self, client, target)
-		if client:GetCharacter() == target then return end
+		if client:GetCharacter() == target then
+			return "@invalidInventory
+		end
 
 		local clientInv = client:GetCharacter():GetInventory()
 		local targetInv = target:GetInventory()
@@ -802,6 +804,8 @@ ix.command.Add("CheckInventory", {
 				searchTime = 0,
 				data = {money = target:GetMoney()}
 			})
+		else
+			return "@invalidInventory"
 		end
 	end
 })

--- a/gamemode/core/sh_commands.lua
+++ b/gamemode/core/sh_commands.lua
@@ -784,3 +784,24 @@ ix.command.Add("MapRestart", {
 		end)
 	end
 })
+
+ix.command.Add("CheckInventory", {
+	description = "@cmdCheckInventory",
+	adminOnly = true,
+	arguments = ix.type.character,
+	OnRun = function(self, client, target)
+		if client:GetCharacter() == target then return end
+
+		local clientInv = client:GetCharacter():GetInventory()
+		local targetInv = target:GetInventory()
+
+		if (clientInv and targetInv) then
+			ix.storage.Open(client, targetInv, {
+				name = target:GetName().."'s Inventory",
+				entity = target:GetPlayer(),
+				searchTime = 0,
+				data = {money = target:GetMoney()}
+			})
+		end
+	end
+})

--- a/gamemode/core/sh_commands.lua
+++ b/gamemode/core/sh_commands.lua
@@ -791,7 +791,7 @@ ix.command.Add("CheckInventory", {
 	arguments = ix.type.character,
 	OnRun = function(self, client, target)
 		if client:GetCharacter() == target then
-			return "@invalidInventory
+			return "@invalidInventory"
 		end
 
 		local clientInv = client:GetCharacter():GetInventory()

--- a/gamemode/languages/sh_english.lua
+++ b/gamemode/languages/sh_english.lua
@@ -441,5 +441,6 @@ LANGUAGE = {
 	cmdY = "Yell something to the people around you.",
 	cmdEvent = "Make something perform an action that everyone can see.",
 	cmdOOC = "Sends a message in global out-of-character chat.",
-	cmdLOOC = "Sends a message in local out-of-character chat."
+	cmdLOOC = "Sends a message in local out-of-character chat.",
+	cmdCheckInventory = "Accesses another character's inventory."
 }


### PR DESCRIPTION
I re-utilized the storage plugin to allow admins to check other character's inventories. This is especially helpful when it comes to players stealing items from other players, or checking to see if players are duping items, or have access to items that shouldn't be in circulation.

It's also helpful for admins who want to transfer over items in their inventory to other character's around the map quickly.