### PR TITLE
removal of IX: prefix for gamemode

### DIFF
--- a/gamemode/core/hooks/sv_hooks.lua
+++ b/gamemode/core/hooks/sv_hooks.lua
@@ -747,10 +747,6 @@ function GM:ShutDown()
 	end
 end
 
-function GM:GetGameDescription()
-	return "IX: "..(Schema and Schema.name or "Unknown")
-end
-
 function GM:OnPlayerUseBusiness(client, item)
 	-- You can manipulate purchased items with this hook.
 	-- does not requires any kind of return.

--- a/gamemode/core/hooks/sv_hooks.lua
+++ b/gamemode/core/hooks/sv_hooks.lua
@@ -747,6 +747,10 @@ function GM:ShutDown()
 	end
 end
 
+function GM:GetGameDescription()
+	return (Schema and Schema.name or "Unknown")
+end
+
 function GM:OnPlayerUseBusiness(client, item)
 	-- You can manipulate purchased items with this hook.
 	-- does not requires any kind of return.


### PR DESCRIPTION
Advertised as a free gamemode, doesn't have something clockwork has had for ages, which is abolishing of the CW: prefix.