### PR TITLE
Replacement items even when inventory is full

### DIFF
--- a/gamemode/core/libs/sh_item.lua
+++ b/gamemode/core/libs/sh_item.lua
@@ -831,6 +831,12 @@ do
 					else
 						item:Remove()
 					end
+
+					if (type(result) == "string") then
+						ix.item.inventories[invID or 0]:Add(result, 1)
+					elseif (type(result) == "table") then
+						ix.item.inventories[invID or 0]:Add(result[1], 1, result[2])
+					end
 				end
 
 				item.entity = nil


### PR DESCRIPTION
`return "health_vial"`

will spawn a health_vial in inventory after deleting previous item

you can also send data tables ->

`return {"cid", {
	name = client:GetCharacter():GetName(),
	id = client:GetCharacter():GetData("cid")
}}
`