### PR TITLE
ITEM:Transfer doesn't need to set item's inventory ID

### DIFF
--- a/gamemode/core/meta/sh_item.lua
+++ b/gamemode/core/meta/sh_item.lua
@@ -482,7 +482,6 @@ if (SERVER) then
 					if (self.invID > 0 and prevID != 0) then
 						-- we are transferring this item from one inventory to another
 						curInv:Remove(self.id, false, true, true)
-						self.invID = invID
 
 						if (self.OnTransferred) then
 							self:OnTransferred(curInv, inventory)


### PR DESCRIPTION
This is useful if targetInv is a bag inventory

Instead of changing item.invID back to what was initially passed with ITEM:Transfer() we'll just let the targetInv:Add function set the invID. Setting the invID after targetInv:Add will not work if targetInv was not the same inventory as the invID passed with ITEM:Transfer().