### PR TITLE
Hook call priority system

### DIFF
--- a/gamemode/core/libs/sh_plugin.lua
+++ b/gamemode/core/libs/sh_plugin.lua
@@ -13,10 +13,10 @@ local function insertSorted(tbl, plugin, func, priority)
 		-- Clean out the old function from the table
 		for i = 1, #tbl do
 			if (tbl[i][1] == plugin) then
-				table.remove(tbl, k)
+				table.remove(tbl, i)
 				break
 			end
-		end	
+		end
 	end
 
 	-- Attempt to insert into an empty table or at the end first
@@ -24,7 +24,7 @@ local function insertSorted(tbl, plugin, func, priority)
 		tbl[#tbl + 1] = {plugin, func, priority}
 		return
 	end
-	
+
 	-- Find where to insert
 	for i = #tbl - 1, 1, -1 do
 		if (tbl[i][3] >= priority) then
@@ -108,7 +108,9 @@ function ix.plugin.Load(uniqueID, path, isSingleFile, variable)
 		for k, v in pairs(PLUGIN) do
 			if (isfunction(v)) then
 				HOOKS_CACHE[k] = HOOKS_CACHE[k] or {}
-				insertSorted(HOOKS_CACHE[k], PLUGIN, v, (PLUGIN.GetHookCallPriority and PLUGIN:GetHookCallPriority(k)) or PLUGIN.hookCallPriority)
+				insertSorted(HOOKS_CACHE[k], PLUGIN, v,
+					(PLUGIN.GetHookCallPriority and PLUGIN:GetHookCallPriority(k))
+					or PLUGIN.hookCallPriority)
 			end
 		end
 
@@ -128,7 +130,7 @@ function ix.plugin.GetHook(pluginName, hookName)
 		local p = ix.plugin.list[pluginName]
 
 		if (p) then
-			for k, v in ipairs(h) do
+			for _, v in ipairs(h) do
 				if (v[1] == p) then
 					return v[2]
 				end


### PR DESCRIPTION
Allows plugins to determine their call priority:
- Either using PLUGIN.hookCallPriority to set their priority for all functions
- Or using PLUGIN:GetHookCallPriority(hookName) which should return the priority for that specific hookName

Default call priority is 1000. So any priority larger than 1000 will get called first, smaller than 1000 will get called later.

During load, the HOOKS_CACHE is built into a sorted array with the highest priority functions first. When calling a hook, all functions in the array are called in order (so from highest priority to lowest priority).

Some things that I considered already:
- For plugins without any priority specified, call order will remain the same as is now, being the order in which plugins are loaded. This is done by requiring the priority to be strictly larger to be called first.
- Performance impact is entirely during load/refresh, where some additional table iterations need to happen. The impact on load is minimized by attempting to insert at the end first, and then from the end to the front (the vast majority of functions will have default priority and will be inserted at or near the end).
- Performance during runtime should be entirely equal or better. I changed iteration from the slow 'pairs' to the much faster 'for i = 1, #cache do', but need to do 4 array look-ups.
- On refresh, old entries in the cache are deleted prior to the new entry being inserted (previously they were simply overwritten). This ensures any priority changes properly refresh.