### PR TITLE
Weapon consistency when ragdolling

### DIFF
--- a/gamemode/items/base/sh_weapons.lua
+++ b/gamemode/items/base/sh_weapons.lua
@@ -118,7 +118,7 @@ function ITEM:RemovePAC(client)
 	end
 end
 
-function ITEM:Equip(client)
+function ITEM:Equip(client, bNoSelect, bNoSound)
 	local items = client:GetCharacter():GetInventory():GetItems()
 
 	client.carryWeapons = client.carryWeapons or {}
@@ -151,8 +151,14 @@ function ITEM:Equip(client)
 		local ammoType = weapon:GetPrimaryAmmoType()
 
 		client.carryWeapons[self.weaponCategory] = weapon
-		client:SelectWeapon(weapon:GetClass())
-		client:EmitSound("items/ammo_pickup.wav", 80)
+
+		if (!bNoSelect) then
+			client:SelectWeapon(weapon:GetClass())
+		end
+
+		if (!bNoSound) then
+			client:EmitSound("items/ammo_pickup.wav", 80)
+		end
 
 		-- Remove default given ammo.
 		if (client:GetAmmoCount(ammoType) == weapon:Clip1() and self:GetData("ammo", 0) == 0) then


### PR DESCRIPTION
Couple of changes in here to make ragdolling more consistent in terms of the player's equipped weapons.

The main change leverages the weapon's base equip & unequip code to consistently store equipped item weapons (including the loaded clip). Any extensions made in custom weapon bases using ITEM.OnEquipWeapon & ITEM.OnUnequipWeapon to store additional information etc. will also be properly called. This also removes the need to write extra code to make ragdolling consistent, only equipping and unequipping needs to be made consistent.

As the item will be unequipped, it can be moved out of the player's inventory while he is ragdolled. An additional check is added to see if the weapon is still in the same inventory to know if it should be re-equipped.

For non-item based weapons, the clip is also stored and restored so you don't end up with an empty magazine.

Due to the clip being stored separately, ammo saving & restoring no longer causes ammo loss if there are multiple weapons with the same ammo type equipped by the player with ammunition loaded into the clip of both weapons.

Also made a small change in the weapon base to optionally suppress equip sound & weapon selection.