### PR TITLE
Update sv_hooks.lua

### DIFF
--- a/plugins/area/sv_hooks.lua
+++ b/plugins/area/sv_hooks.lua
@@ -59,13 +59,17 @@ function PLUGIN:AreaThink()
 			local oldID = client:GetArea()
 			local id = overlappingBoxes[1]
 
-			if (oldID != id) then
+			if (!client.ixInArea or oldID != id) then
 				hook.Run("OnPlayerAreaChanged", client, client.ixArea, id)
 				client.ixArea = id
 			end
 
 			client.ixInArea = true
 		else
+			if (client.ixInArea) then
+				hook.Run("OnPlayerAreaChanged", client, client.ixArea)
+			end
+
 			client.ixInArea = false
 		end
 	end
@@ -74,7 +78,11 @@ end
 function PLUGIN:OnPlayerAreaChanged(client, oldID, newID)
 	net.Start("ixAreaChanged")
 		net.WriteString(oldID)
-		net.WriteString(newID)
+
+		if (newID) then
+			net.WriteString(newID)
+		end
+
 	net.Send(client)
 end
 


### PR DESCRIPTION
Fixed an issue with the areas plugin. If you go into any area and then leave it, client:IsInArea() is always true on the client. By changing the code in these two functions it fixes it. There's probably a better way to fix this, but mainly just wanted to inform of the issue and present a potential fix.