### PR TITLE
CanHear range properly uses data.range

### DIFF
--- a/gamemode/core/libs/sh_chatbox.lua
+++ b/gamemode/core/libs/sh_chatbox.lua
@@ -46,7 +46,7 @@ function ix.chat.Register(chatType, data)
 
 		function data:CanHear(speaker, listener)
 			-- Length2DSqr is faster than Length2D, so just check the squares.
-			return (speaker:GetPos() - listener:GetPos()):LengthSqr() <= range
+			return (speaker:GetPos() - listener:GetPos()):LengthSqr() <= self.range
 		end
 	end
 


### PR DESCRIPTION
Currently there is no way to change the range after the chat class has been created as the local 'range' variable is used in the function, rather than data.range.