### PR TITLE
Ability to close chatbox with escape

### DIFF
--- a/plugins/chatbox/derma/cl_chatbox.lua
+++ b/plugins/chatbox/derma/cl_chatbox.lua
@@ -1069,14 +1069,13 @@ function PANEL:OnMouseReleased()
 end
 
 function PANEL:Think()
-	if (gui.IsGameUIVisible() and self.bActive) or (input.IsKeyDown(KEY_ESCAPE)) then
+	if (input.IsKeyDown(KEY_ESCAPE) and self.bActive) then
 		if (self.bSizing or self.DragOffset) then
 			self:OnMouseReleased(MOUSE_LEFT) -- make sure we aren't still sizing/dragging anything
 		end
 
 		self:SetActive(false)
-
-		if (input.IsKeyDown(KEY_ESCAPE)) then RunConsoleCommand("cancelselect") end
+		RunConsoleCommand("cancelselect")
 		return
 	end
 

--- a/plugins/chatbox/derma/cl_chatbox.lua
+++ b/plugins/chatbox/derma/cl_chatbox.lua
@@ -1069,12 +1069,14 @@ function PANEL:OnMouseReleased()
 end
 
 function PANEL:Think()
-	if (gui.IsGameUIVisible() and self.bActive) then
+	if (gui.IsGameUIVisible() and self.bActive) or (input.IsKeyDown(KEY_ESCAPE)) then
 		if (self.bSizing or self.DragOffset) then
 			self:OnMouseReleased(MOUSE_LEFT) -- make sure we aren't still sizing/dragging anything
 		end
 
 		self:SetActive(false)
+
+		if (input.IsKeyDown(KEY_ESCAPE)) then RunConsoleCommand("cancelselect") end
 		return
 	end
 

--- a/plugins/chatbox/derma/cl_chatbox.lua
+++ b/plugins/chatbox/derma/cl_chatbox.lua
@@ -1068,16 +1068,22 @@ function PANEL:OnMouseReleased()
 	end
 end
 
-function PANEL:Think()
-	if (input.IsKeyDown(KEY_ESCAPE) and self.bActive) then
-		if (self.bSizing or self.DragOffset) then
-			self:OnMouseReleased(MOUSE_LEFT) -- make sure we aren't still sizing/dragging anything
-		end
+function PANEL:ClosePanel()
+	if (self.bSizing or self.DragOffset) then
+		self:OnMouseReleased(MOUSE_LEFT) -- make sure we aren't still sizing/dragging anything
+	end
 
-		self:SetActive(false)
+	self:SetActive(false)
+end
+
+function PANEL:Think()
+	if ((input.IsKeyDown(KEY_ESCAPE)) and self.bActive) then
+		self:ClosePanel()
 		RunConsoleCommand("cancelselect")
 		return
 	end
+
+	if (gui.IsGameUIVisible()) then self:ClosePanel() return end
 
 	if (!self.bActive) then
 		return


### PR DESCRIPTION
It's very annoying to revert all your text and press enter to cancel typing, or having to go through the main menu when canceling, this commit allows you to just click escape in the chatbox and then it closes (as is standard with the default chatbox & practically all other games)