### PR TITLE
"L" function now returns sensible values.

### DIFF
--- a/gamemode/core/libs/sh_language.lua
+++ b/gamemode/core/libs/sh_language.lua
@@ -75,7 +75,7 @@ if (SERVER) then
 		local langKey = ix.option.Get(client, "language", "english")
 		local info = languages[langKey] or languages.english
 
-		return string.format(info and info[key] or key, ...)
+		return string.format(info and info[key] or languages.english[key] or key, ...)
 	end
 
 	-- luacheck: globals L2
@@ -94,7 +94,7 @@ else
 		local langKey = ix.option.Get("language", "english")
 		local info = languages[langKey] or languages.english
 
-		return string.format(info and info[key] or key, ...)
+		return string.format(info and info[key] or languages.english[key] or key, ...)
 	end
 
 	function L2(key, ...)


### PR DESCRIPTION
## Summary of the Pull Request 📕
"L" function now returns the English phrase if the phrase in the requested language could not be found.

## Demonstration 📷
An meaningful example would be the Area plugin, as it contains untranslated phrases.

As you can see in the image below, if the user is using a language other than English, the "keys" will appear instead of a more descriptive text.
![image](https://user-images.githubusercontent.com/5395186/96263953-f21da300-0fc3-11eb-8646-43517f084d25.png)
The next image shows how it would look with the fix applied and without the user needing to change his language.
![image](https://user-images.githubusercontent.com/5395186/96264725-c9e27400-0fc4-11eb-955e-2c7045e69f19.png)

