### PR TITLE
Prevent DComboBox from going off screen,

### DIFF
--- a/gamemode/core/derma/cl_overrides.lua
+++ b/gamemode/core/derma/cl_overrides.lua
@@ -205,7 +205,7 @@ OverridePanel("DComboBox", function()
 
 		if (IsValid(self.Menu)) then
 			self.Menu:SetFont(self:GetFont())
-			local x,y = self.Menu:LocalToScreen( self.Menu:GetPos() )
+			local _, y = self.Menu:LocalToScreen(self.Menu:GetPos())
 			self.Menu:SetMaxHeight(ScrH() - y)
 		end
 	end

--- a/gamemode/core/derma/cl_overrides.lua
+++ b/gamemode/core/derma/cl_overrides.lua
@@ -204,8 +204,9 @@ OverridePanel("DComboBox", function()
 		self:ixOpenMenu()
 
 		if (IsValid(self.Menu)) then
-			self.Menu:SetFont(self:GetFont())
 			local _, y = self.Menu:LocalToScreen(self.Menu:GetPos())
+
+			self.Menu:SetFont(self:GetFont())
 			self.Menu:SetMaxHeight(ScrH() - y)
 		end
 	end

--- a/gamemode/core/derma/cl_overrides.lua
+++ b/gamemode/core/derma/cl_overrides.lua
@@ -205,6 +205,8 @@ OverridePanel("DComboBox", function()
 
 		if (IsValid(self.Menu)) then
 			self.Menu:SetFont(self:GetFont())
+			local x,y = self.Menu:LocalToScreen( self.Menu:GetPos() )
+			self.Menu:SetMaxHeight(ScrH() - y)
 		end
 	end
 end)


### PR DESCRIPTION
DComboBox will go off screen if there are too many elements, meaning some elements are not accessible. This stops it the bottom of the screen.