### PR TITLE
Use gmod language by default.

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -15,6 +15,7 @@ stds.helix.globals = {
 	"PLUGIN",
 	"ATTRIBUTE",
 	"NAME",
+	"CODE",
 	"LANGUAGE",
 	"FACTION",
 	"CLASS",

--- a/gamemode/config/sh_config.lua
+++ b/gamemode/config/sh_config.lua
@@ -1,6 +1,6 @@
 
 -- You can change the default language by setting this in your schema.
-ix.config.language = "english"
+-- ix.config.language = "english"
 
 --[[
 	DO NOT CHANGE ANYTHING BELOW THIS.

--- a/gamemode/config/sh_options.lua
+++ b/gamemode/config/sh_options.lua
@@ -45,25 +45,30 @@ if (CLIENT) then
 	})
 end
 
-ix.option.Add("language", ix.type.array, ix.config.language or "english", {
-	category = "general",
-	bNetworked = true,
-	populate = function()
-		local entries = {}
+do
+	local gmodLanguage = GetConVar("gmod_language"):GetString()
+	local defaultLanguage = ix.config.language or ix.lang.codes[gmodLanguage] or "english"
 
-		for k, _ in SortedPairs(ix.lang.stored) do
-			local name = ix.lang.names[k]
-			local name2 = k:utf8sub(1, 1):utf8upper() .. k:utf8sub(2)
-
-			if (name) then
-				name = name .. " (" .. name2 .. ")"
-			else
-				name = name2
+	ix.option.Add("language", ix.type.array, defaultLanguage, {
+		category = "general",
+		bNetworked = true,
+		populate = function()
+			local entries = {}
+	
+			for k, _ in SortedPairs(ix.lang.stored) do
+				local name = ix.lang.names[k]
+				local name2 = k:utf8sub(1, 1):utf8upper() .. k:utf8sub(2)
+	
+				if (name) then
+					name = name .. " (" .. name2 .. ")"
+				else
+					name = name2
+				end
+	
+				entries[k] = name
 			end
-
-			entries[k] = name
+	
+			return entries
 		end
-
-		return entries
-	end
-})
+	})
+end

--- a/gamemode/config/sh_options.lua
+++ b/gamemode/config/sh_options.lua
@@ -54,20 +54,20 @@ do
 		bNetworked = true,
 		populate = function()
 			local entries = {}
-	
+
 			for k, _ in SortedPairs(ix.lang.stored) do
 				local name = ix.lang.names[k]
 				local name2 = k:utf8sub(1, 1):utf8upper() .. k:utf8sub(2)
-	
+
 				if (name) then
 					name = name .. " (" .. name2 .. ")"
 				else
 					name = name2
 				end
-	
+
 				entries[k] = name
 			end
-	
+
 			return entries
 		end
 	})

--- a/gamemode/core/libs/sh_language.lua
+++ b/gamemode/core/libs/sh_language.lua
@@ -32,6 +32,7 @@ does not have a set language. An example:
 ix.lang = ix.lang or {}
 ix.lang.stored = ix.lang.stored or {}
 ix.lang.names = ix.lang.names or {}
+ix.lang.codes = ix.lang.codes or {}
 
 --- Loads language files from a directory.
 -- @realm shared
@@ -47,6 +48,11 @@ function ix.lang.LoadFromDir(directory)
 			if (NAME) then
 				ix.lang.names[niceName] = NAME
 				NAME = nil
+			end
+
+			if (CODE) then
+				ix.lang.codes[CODE] = niceName
+				CODE = nil
 			end
 
 			ix.lang.AddTable(niceName, LANGUAGE)

--- a/gamemode/languages/sh_dutch.lua
+++ b/gamemode/languages/sh_dutch.lua
@@ -1,6 +1,7 @@
 
 -- DUTCH TRANSLATION - http://steamcommunity.com/profiles/76561198084653538/
 NAME = "Nederlands"
+CODE = "nl"
 
 LANGUAGE = {
 	loading = "Laden",

--- a/gamemode/languages/sh_english.lua
+++ b/gamemode/languages/sh_english.lua
@@ -1,5 +1,6 @@
 
 NAME = "English"
+CODE = "en"
 
 LANGUAGE = {
 	helix = "Helix",

--- a/gamemode/languages/sh_french.lua
+++ b/gamemode/languages/sh_french.lua
@@ -3,7 +3,8 @@
 -- http://steamcommunity.com/id/sadness81
 -- https://steamcommunity.com/id/Azphal
 
-NAME = "Français"
+NAME = "Français"	
+CODE = "fr"
 
 LANGUAGE = {
 	helix = "Helix",

--- a/gamemode/languages/sh_french.lua
+++ b/gamemode/languages/sh_french.lua
@@ -3,7 +3,7 @@
 -- http://steamcommunity.com/id/sadness81
 -- https://steamcommunity.com/id/Azphal
 
-NAME = "Français"	
+NAME = "Français"
 CODE = "fr"
 
 LANGUAGE = {

--- a/gamemode/languages/sh_korean.lua
+++ b/gamemode/languages/sh_korean.lua
@@ -1,5 +1,6 @@
 
 NAME = "한국어"
+CODE = "ko"
 
 LANGUAGE = {
 	loading = "불러오는 중",

--- a/gamemode/languages/sh_norwegian.lua
+++ b/gamemode/languages/sh_norwegian.lua
@@ -1,5 +1,6 @@
 
 NAME = "Norwegian"
+CODE = "no"
 
 LANGUAGE = {
 	loading = "Laster",

--- a/gamemode/languages/sh_polish.lua
+++ b/gamemode/languages/sh_polish.lua
@@ -1,6 +1,7 @@
 -- Autorzy: zgredinzyyy (Poprawki + Brakujące rzeczy) || Veran120, Michał, Lechu2375 https://github.com/lechu2375/helix-polishlocalization/blob/master/sh_polish.lua
 
 NAME = "Polski"
+CODE = "pl"
 
 LANGUAGE = {
 	helix = "Helix",

--- a/gamemode/languages/sh_portuguese.lua
+++ b/gamemode/languages/sh_portuguese.lua
@@ -1,4 +1,5 @@
 NAME = "Portuguese"
+CODE = "pt-PT"
 
 LANGUAGE = {
 	helix = "Helix",

--- a/gamemode/languages/sh_russian.lua
+++ b/gamemode/languages/sh_russian.lua
@@ -1,5 +1,6 @@
 --Maybe this thing have some trouble with translate
 NAME = "Русский"
+CODE = "ru"
 
 LANGUAGE = {
 	helix = "Helix",

--- a/gamemode/languages/sh_spanish.lua
+++ b/gamemode/languages/sh_spanish.lua
@@ -1,5 +1,6 @@
 
 NAME = "Español"
+CODE = "es-ES"
 
 LANGUAGE = {
 	helix = "Helix",


### PR DESCRIPTION
Helix uses English as its default language, but this is not user friendly for those who have gmod set to use a different one. This PR allows Helix to respect whatever language players have selected for gmod.

However, what I was interested in while making these changes is the importance of `ix.config.language`. It currently has the highest precedence when choosing which language to consider the default. I couldn't find any references to it other than where it is defined and where the language option is added. Is this a variable that can be removed or given less priority than the players' gmod language without any adverse effects?

I want to add one more thing to this PR, but before moving forward with that, I'd like to know if we can simplify some of this.