### PR TITLE
Add hook for after player DB loaded

### DIFF
--- a/gamemode/core/hooks/sv_hooks.lua
+++ b/gamemode/core/hooks/sv_hooks.lua
@@ -46,6 +46,8 @@ function GM:PlayerInitialSpawn(client)
 			net.WriteUInt(client.ixPlayTime or 0, 32)
 		net.Send(client)
 
+		hook.Run("PlayerInitialized", client)
+
 		ix.char.Restore(client, function(charList)
 			if (!IsValid(client)) then return end
 


### PR DESCRIPTION
Currently no hooks for after player DB loaded. It meaning 'ix_players' DB used plugins can't initialize player when player connected.

I tried PlayerInitialSpawn hook, but plugin hook called before framework hook.