### PR TITLE
Trim chat message if it should be autoformated

### DIFF
--- a/gamemode/core/libs/sh_chatbox.lua
+++ b/gamemode/core/libs/sh_chatbox.lua
@@ -238,6 +238,8 @@ if (SERVER) then
 			end
 
 			if (ix.config.Get("chatAutoFormat") and hook.Run("CanAutoFormatMessage", speaker, chatType, text)) then
+				text = string.Trim(text)
+
 				local last = text:utf8sub(-1)
 
 				if (last != "." and last != "?" and last != "!" and last != "-" and last != "\"") then


### PR DESCRIPTION
The purpose is to prevent situations like the one below:
![trim](https://user-images.githubusercontent.com/51002485/103107717-fa442f80-4651-11eb-8df5-51665012e984.png)
