### PR TITLE
Format slider lib to number of decimal places

### DIFF
--- a/gamemode/core/derma/cl_generic.lua
+++ b/gamemode/core/derma/cl_generic.lua
@@ -391,7 +391,7 @@ function PANEL:Init()
 		self:OnValueChanged()
 	end
 	self.slider.OnValueUpdated = function(panel)
-		self.label:SetText(tostring(panel:GetValue()))
+		self.label:SetText(string.format("%0." .. tostring(panel:GetDecimals()) .. "f", tostring(panel:GetValue())))
 		self.label:SizeToContents()
 
 		self:OnValueUpdated()
@@ -410,7 +410,7 @@ function PANEL:SetValue(value, bNoNotify)
 	value = tonumber(value) or self.slider:GetMin()
 
 	self.slider:SetValue(value, bNoNotify)
-	self.label:SetText(tostring(self.slider:GetValue()))
+	self.label:SetText(string.format("%0." .. tostring(self:GetDecimals()) .. "f", tostring(self.slider:GetValue())))
 	self.label:SizeToContents()
 end
 


### PR DESCRIPTION
It is very wonky because the size changes all the time if you don't do it like this and it makes using sliders with decimal points a pain.

Before:
![2BvOU9w5Bk](https://user-images.githubusercontent.com/7416288/103463198-62ba9d00-4d33-11eb-8d6b-92e61d07a836.gif)

After:
![E3FnThRrtu](https://user-images.githubusercontent.com/7416288/103463202-664e2400-4d33-11eb-96e0-8f88eb19d6f2.gif)
