### PR TITLE
Fix ix.bar.totalHeight not being set when bars are created.

### DIFF
--- a/gamemode/core/libs/cl_bar.lua
+++ b/gamemode/core/libs/cl_bar.lua
@@ -27,6 +27,8 @@ function ix.bar.Remove(identifier)
 		end
 
 		table.remove(ix.bar.list, bar.index)
+
+		ix.bar.totalHeight = ix.bar.totalHeight - BAR_HEIGHT
 	end
 end
 
@@ -48,6 +50,8 @@ function ix.bar.Add(getValue, color, priority, identifier)
 		identifier = identifier,
 		panel = IsValid(ix.gui.bars) and ix.gui.bars:AddBar(index, color, priority)
 	}
+
+	ix.bar.totalHeight = ix.bar.totalHeight + BAR_HEIGHT
 
 	return priority
 end


### PR DESCRIPTION
This causes a bug in the HL2RP schema where the Combine Display Text is overlapping the bars.