### PR TITLE
Prevent trace from returning a nil value

### DIFF
--- a/gamemode/core/hooks/cl_hooks.lua
+++ b/gamemode/core/hooks/cl_hooks.lua
@@ -439,11 +439,7 @@ timer.Create("ixVignetteChecker", 1, 0, function()
 			data.filter = client
 		local trace = util.TraceLine(data)
 
-		if trace == nil then
-			vignetteAlphaGoal = 0
-		end
-
-		if (trace.Hit) then
+		if trace ~= nil and (trace.Hit) then
 			vignetteAlphaGoal = 80
 		else
 			vignetteAlphaGoal = 0

--- a/gamemode/core/hooks/cl_hooks.lua
+++ b/gamemode/core/hooks/cl_hooks.lua
@@ -438,6 +438,10 @@ timer.Create("ixVignetteChecker", 1, 0, function()
 			data.endpos = data.start + vignetteTraceHeight
 			data.filter = client
 		local trace = util.TraceLine(data)
+			
+		if trace == nil then
+			vignetteAlphaGoal = 0
+		end
 
 		if (trace.Hit) then
 			vignetteAlphaGoal = 80

--- a/gamemode/core/hooks/cl_hooks.lua
+++ b/gamemode/core/hooks/cl_hooks.lua
@@ -438,7 +438,7 @@ timer.Create("ixVignetteChecker", 1, 0, function()
 			data.endpos = data.start + vignetteTraceHeight
 			data.filter = client
 		local trace = util.TraceLine(data)
-			
+
 		if trace == nil then
 			vignetteAlphaGoal = 0
 		end


### PR DESCRIPTION
Minor issue which tends to spit out an error upon spawning.