### PR TITLE
Prevent error on nil trace

### DIFF
--- a/gamemode/core/hooks/cl_hooks.lua
+++ b/gamemode/core/hooks/cl_hooks.lua
@@ -439,7 +439,7 @@ timer.Create("ixVignetteChecker", 1, 0, function()
 			data.filter = client
 		local trace = util.TraceLine(data)
 
-		if (trace.Hit) then
+		if trace ~= nil and (trace.Hit) then
 			vignetteAlphaGoal = 80
 		else
 			vignetteAlphaGoal = 0


### PR DESCRIPTION
Minor issue which tends to spit out an error upon spawning.