### PR TITLE
Fix 3dtext with undo not saving and add undo to 3dpanels

### DIFF
--- a/plugins/3dtext.lua
+++ b/plugins/3dtext.lua
@@ -87,6 +87,7 @@ if (SERVER) then
 		net.Broadcast()
 
 		self.list[id] = nil
+		self:SaveText()
 		return true
 	end
 


### PR DESCRIPTION
3DText removed by undo would not save after a restart. Only /textremove would save the removal.
Added the ability to remove 3DPanels with undo