### PR TITLE
Fix ExtractArgs counting UTF-8 chars incorrectly under certain circumstances

### DIFF
--- a/gamemode/core/libs/sh_command.lua
+++ b/gamemode/core/libs/sh_command.lua
@@ -349,7 +349,7 @@ function ix.command.ExtractArgs(text)
 
 			if (match) then
 				curString = ""
-				skip = i + #match
+				skip = i + match:utf8len()
 				arguments[#arguments + 1] = match:utf8sub(2, -2)
 			else
 				curString = curString..c


### PR DESCRIPTION
If we putting command arguments inside quation marks, for example, using "/TextAdd" command, then it counts every single UTF-8 character inside as 2 characters. This pull request aims to fix this respectively.

Before:
![pull1](https://user-images.githubusercontent.com/51002485/111085269-dc110180-84d3-11eb-8b9f-d1628ca4b600.png)
![pull2](https://user-images.githubusercontent.com/51002485/111085274-e16e4c00-84d3-11eb-982a-4272e8234ab6.png)
After:
![pull3](https://user-images.githubusercontent.com/51002485/111085277-e7fcc380-84d3-11eb-8d42-700871c0364e.png)