### PR TITLE
Added a gamemode (framework) category to helix.txt

### DIFF
--- a/helix.txt
+++ b/helix.txt
@@ -3,4 +3,5 @@
 	"base"		"sandbox"
 	"title"		"Helix"
 	"author"	"nebulous.cloud"
+	"category"	"rp"
 }


### PR DESCRIPTION
Due to the March update of Gmod.
Some gamemodes using Helix do not contain RP in their name, so I would like to add a category field to the Helix framework.