### PR TITLE
Prevent players from returning to the kicked or banned character via return button

### DIFF
--- a/gamemode/core/derma/cl_character.lua
+++ b/gamemode/core/derma/cl_character.lua
@@ -295,11 +295,11 @@ function PANEL:Init()
 end
 
 function PANEL:UpdateReturnButton(bValue)
-	if (bValue == nil) then
-		bValue = self.bUsingCharacter
+	if (bValue != nil) then
+		self.bUsingCharacter = bValue
 	end
 
-	self.returnButton:SetText(bValue and "return" or "leave")
+	self.returnButton:SetText(self.bUsingCharacter and "return" or "leave")
 	self.returnButton:SizeToContents()
 end
 


### PR DESCRIPTION
Only `bUsingCharacter` variable determines what will happen on return button click. And so, this PR aims to make `UpdateReturnButton` function change `bUsingCharacter`.