### PR TITLE
Use utf8 functions on GetContentSize and DrawKernedText

### DIFF
--- a/gamemode/core/derma/cl_generic.lua
+++ b/gamemode/core/derma/cl_generic.lua
@@ -760,8 +760,8 @@ function PANEL:DrawKernedText(width, height)
 	local contentWidth, contentHeight = self:GetContentSize()
 	local x, y = self:CalculateAlignment(width, height, contentWidth, contentHeight)
 
-	for i = 1, #self.text do
-		local character = self.text[i]
+	for i = 1, self.text:utf8len() do
+		local character = self.text:utf8sub(i, i)
 		local textWidth, _ = surface.GetTextSize(character)
 		local kerning = i == 1 and 0 or self.kerning
 		local shadowDistance = self.shadowDistance
@@ -857,8 +857,8 @@ function PANEL:GetContentSize(bCalculate)
 		if (self.kerning > 0) then
 			local width = 0
 
-			for i = 1, #self.text do
-				local textWidth, _ = surface.GetTextSize(self.text[i])
+			for i = 1, self.text:utf8len() do
+				local textWidth, _ = surface.GetTextSize(self.text:utf8sub(i, i))
 				width = width + textWidth + self.kerning
 			end
 


### PR DESCRIPTION
Fixes text drawn via `DrawKernedText` showing `�` symbols if providen text has non-latin characters and `GetContentSize` returning incorrect size of text in the same circumstances.

For example let's take a look at how it affects credits in help menu.
Without this commit:
![image](https://user-images.githubusercontent.com/51002485/115261818-ce5d2600-a0e8-11eb-98ce-7b3f9ea15eca.png)

With this commit:
![image](https://user-images.githubusercontent.com/51002485/115261959-f0ef3f00-a0e8-11eb-97a7-807c1b852a58.png)