### PR TITLE
Fixed Lua errors when a bar was deleted

### DIFF
--- a/gamemode/core/derma/cl_bar.lua
+++ b/gamemode/core/derma/cl_bar.lua
@@ -49,9 +49,14 @@ function PANEL:RemoveBar(panel)
 	local toRemove
 
 	for k, v in ipairs(self.bars) do
+		if (toRemove) then
+			-- Decrease index value for the next bars
+			ix.bar.list[k].index = k - 1
+			self.bars[k]:SetID(k - 1)
+		end
+
 		if (v == panel) then
 			toRemove = k
-			break
 		end
 	end
 


### PR DESCRIPTION
In summary, deleting a bar always results in a Lua error because the script wants to retrieve information from a bar (through an index) that simply does not exist. By updating all indexes when the bar is deleted, then the problem is solved.

### Trace error
```
[ERROR] gamemodes/helix/gamemode/core/derma/cl_bar.lua:108: attempt to index local 'info' (a nil value)
  1. unknown - gamemodes/helix/gamemode/core/derma/cl_bar.lua:108
```

### Reproduction

This error can be generated easily using the gamemode currently on github without any addon/plugin. Just execute a simple piece of code to trigger the error: `ix.bar.Remove("armor")`.

### Notes

Before posting this pull request, it seems that other users (on the Helix Discord) have encountered the same issue without having a durable solution. As this is my first pull request on this repository, if you have any suggestions to improve it, I'm listening! 👍 