### PR TITLE
Added missing :lower() invokes

### DIFF
--- a/plugins/containers/sh_plugin.lua
+++ b/plugins/containers/sh_plugin.lua
@@ -18,7 +18,7 @@ ix.config.Add("containerOpenTime", 0.7, "How long it takes to open a container."
 })
 
 function ix.container.Register(model, data)
-	ix.container.stored[model] = data
+	ix.container.stored[model:lower()] = data
 end
 
 ix.util.Include("sh_definitions.lua")
@@ -39,7 +39,7 @@ if (SERVER) then
 			container:SetModel(model)
 			container:Spawn()
 
-			ix.inventory.New(0, "container:" .. model, function(inventory)
+			ix.inventory.New(0, "container:" .. model:lower(), function(inventory)
 				-- we'll technically call this a bag since we don't want other bags to go inside
 				inventory.vars.isBag = true
 				inventory.vars.isContainer = true


### PR DESCRIPTION
The key to access on the ix.container.stored table hasn't always had the :lower() method which leads to problems with container models which have capital characters in their path.