### PR TITLE
Allow the modification of the 3D text color

### DIFF
--- a/plugins/3dtext.lua
+++ b/plugins/3dtext.lua
@@ -121,7 +121,7 @@ else
 
 	language.Add("Undone_ix3dText", "Removed 3D Text")
 
-	local function HexColor(str)
+	local function HexToRGB(str)
 		local color
 
 		if (str:sub(1, 1) == "#") then
@@ -168,7 +168,7 @@ else
 		local scale = net.ReadFloat()
 		local color = net.ReadString()
 
-		color = HexColor(color or "FFFFFF")
+		color = HexToRGB(color or "FFFFFF")
 
 		if (text != "") then
 			PLUGIN.list[index] = {
@@ -212,7 +212,7 @@ else
 				continue
 			end
 
-			local rgbaColor = HexColor(v[5] or "FFFFFF")
+			local rgbaColor = HexToRGB(v[5] or "FFFFFF")
 			local object = ix.markup.Parse("<font=ix3D2DFont><colour=" .. rgbaColor.r .. "," .. rgbaColor.g .. "," .. rgbaColor.b .. "," .. rgbaColor.a .. ">" .. v[3]:gsub("\\n", "\n"))
 
 			object.onDrawText = function(text, font, x, y, color, alignX, alignY, alpha)
@@ -286,7 +286,7 @@ else
 			local arguments = ix.chat.currentArguments
 			local text = tostring(arguments[1] or "")
 			local scale = math.Clamp((tonumber(arguments[2]) or 1) * 0.1, 0.001, 5)
-			local color = HexColor(arguments[3] or "FFFFFF")
+			local color = HexToRGB(arguments[3] or "FFFFFF")
 			local trace = LocalPlayer():GetEyeTraceNoCursor()
 			local position = trace.HitPos
 			local angles = trace.HitNormal:Angle()

--- a/plugins/3dtext.lua
+++ b/plugins/3dtext.lua
@@ -134,10 +134,14 @@ else
 			color = tonumber(str, 16)
 		end
 
-		local alpha = bit.band(bit.rshift(color, 24), 0xFF)
-		if (alpha == 0) then alpha = 255 end
+		if color then
+			local alpha = bit.band(bit.rshift(color, 24), 0xFF)
+			if (alpha == 0) then alpha = 255 end
 
-		return Color(bit.band(bit.rshift(color, 16), 0xFF), bit.band(bit.rshift(color, 8), 0xFF), bit.band(color, 0xFF), alpha)
+			return Color(bit.band(bit.rshift(color, 16), 0xFF), bit.band(bit.rshift(color, 8), 0xFF), bit.band(color, 0xFF), alpha)
+		end
+
+		return color_white
 	end
 
 	function PLUGIN:GenerateMarkup(text, rgbaColor)

--- a/plugins/3dtext.lua
+++ b/plugins/3dtext.lua
@@ -121,17 +121,15 @@ else
 
 	language.Add("Undone_ix3dText", "Removed 3D Text")
 
-	local function HexToRGB(str)
+	local function HexToRGB(value)
 		local color
 
-		if (str:sub(1, 1) == "#") then
-			if (#str == 4) then
-				color = tonumber(str:sub(2, 2) .. str:sub(2, 2) .. str:sub(3, 3) .. str:sub(3, 3) .. str:sub(4, 4) .. str:sub(4, 4), 16)
-			else
-				color = tonumber(str:sub(2), 16)
-			end
+		value = string.Replace(value, "#", "")
+
+		if (#value == 3) then
+			color = tonumber(value:sub(1, 1) .. value:sub(1, 1) .. value:sub(2, 2) .. value:sub(2, 2) .. value:sub(3, 3) .. value:sub(3, 3), 16)
 		else
-			color = tonumber(str, 16)
+			color = tonumber(value, 16)
 		end
 
 		if color then

--- a/plugins/3dtext.lua
+++ b/plugins/3dtext.lua
@@ -126,7 +126,7 @@ else
 
 		if (str:sub(1, 1) == "#") then
 			if (#str == 4) then
-				color = tonumber(str[2] .. str[2] .. str[3] .. str[3] .. str[4] .. str[4], 16)
+				color = tonumber(str:sub(2, 2) .. str:sub(2, 2) .. str:sub(3, 3) .. str:sub(3, 3) .. str:sub(4, 4) .. str:sub(4, 4), 16)
 			else
 				color = tonumber(str:sub(2), 16)
 			end
@@ -136,7 +136,9 @@ else
 
 		if color then
 			local alpha = bit.band(bit.rshift(color, 24), 0xFF)
-			if (alpha == 0) then alpha = 255 end
+			if (alpha == 0) then
+				alpha = 255
+			end
 
 			return Color(bit.band(bit.rshift(color, 16), 0xFF), bit.band(bit.rshift(color, 8), 0xFF), bit.band(color, 0xFF), alpha)
 		end


### PR DESCRIPTION
The plugin has been modified so that the texts can be colored according to the players' wishes. A third **optional** argument to the /textadd command has been added. This argument represents the color of the text which must be in **hexadecimal** form. In my opinion, this is the most known and reliable way of transferring a color used by the web development industry to **RGBA**, the only format read by default in Garry's Mod. This modification has been tested for several days and so far there have been no problems. By default and in case of a problem with the value given by a player, the color returns to white by default.