### PR TITLE
Check to make sure player actually entered a name

### DIFF
--- a/gamemode/core/libs/sh_character.lua
+++ b/gamemode/core/libs/sh_character.lua
@@ -327,6 +327,9 @@ do
 		default = "John Doe",
 		index = 1,
 		OnValidate = function(self, value, payload, client)
+			if (!value) then
+				return false, "invalid", "name"
+			end
 			value = tostring(value):gsub("\r\n", ""):gsub("\n", "")
 			value = string.Trim(value)
 

--- a/gamemode/core/libs/sh_character.lua
+++ b/gamemode/core/libs/sh_character.lua
@@ -330,6 +330,7 @@ do
 			if (!value) then
 				return false, "invalid", "name"
 			end
+
 			value = tostring(value):gsub("\r\n", ""):gsub("\n", "")
 			value = string.Trim(value)
 


### PR DESCRIPTION
This will allow minNameLength to be lowered beyond the default 4 if one so chooses. I do not understand why this check was not in place before, I would think it obvious to ensure a value actually exists before trying to perform operations on the value.