### PR TITLE
Fix issue where GetBags could very easily return non-bags.

### DIFF
--- a/gamemode/core/meta/sh_inventory.lua
+++ b/gamemode/core/meta/sh_inventory.lua
@@ -428,6 +428,7 @@ function META:GetBags()
 		for _, v2 in pairs(v) do
 			if (istable(v2) and v2.data) then
 				local isBag = v2.data.id
+				local isBag = (((v2.base == "base_bags") or v2.isBag) and v2.data.id)
 
 				if (!table.HasValue(invs, isBag)) then
 					if (isBag and isBag != self:GetID()) then

--- a/gamemode/core/meta/sh_inventory.lua
+++ b/gamemode/core/meta/sh_inventory.lua
@@ -427,7 +427,6 @@ function META:GetBags()
 	for _, v in pairs(self.slots) do
 		for _, v2 in pairs(v) do
 			if (istable(v2) and v2.data) then
-				local isBag = v2.data.id
 				local isBag = (((v2.base == "base_bags") or v2.isBag) and v2.data.id)
 
 				if (!table.HasValue(invs, isBag)) then


### PR DESCRIPTION
While documenting the Inventory meta I discovered a lazy variable check within `meta/sh_inventory.lua`  that causes it to lazily search if `id` is present within the bag item's data. Seeing as id is a very common word to use for small index searches, this will prevent any mismatches for anything that isn't a bag.