### PR TITLE
Add and Document Get/Set ShouldSave functions for Inventories.

### DIFF
--- a/gamemode/core/meta/sh_inventory.lua
+++ b/gamemode/core/meta/sh_inventory.lua
@@ -551,9 +551,10 @@ if (SERVER) then
 	end
 
 	--- Sets whether  or not an `Inventory` should save.
-	-- This will prevent an `Inventory` from updating in the Database, if the inventory is already saved, it will not be deleted when unloaded.
+	-- This will prevent an `Inventory` from updating in the Database,
+	-- if the inventory is already saved, it will not be deleted when unloaded.
 	-- @realm server
-	-- @bool bNoSave Whether or not the Inventory should save. 
+	-- @bool bNoSave Whether or not the Inventory should save.
 	function META:SetShouldSave(bNoSave)
 		self.noSave = bNoSave
 	end
@@ -566,7 +567,7 @@ if (SERVER) then
 	function META:GetShouldSave()
 		return self.noSave or true
 	end
-	
+
 	--- Add an item to the inventory.
 	-- @realm server
 	-- @param uniqueID The item unique ID (e.g `"handheld_radio"`) or instance ID (e.g `1024`) to add to the inventory

--- a/gamemode/core/meta/sh_inventory.lua
+++ b/gamemode/core/meta/sh_inventory.lua
@@ -550,6 +550,23 @@ if (SERVER) then
 		end
 	end
 
+	--- Sets whether  or not an `Inventory` should save.
+	-- This will prevent an `Inventory` from updating in the Database, if the inventory is already saved, it will not be deleted when unloaded.
+	-- @realm server
+	-- @bool bNoSave Whether or not the Inventory should save. 
+	function META:SetShouldSave(bNoSave)
+		self.noSave = bNoSave
+	end
+
+	--- Gets whether or not an `Inventory` should save.
+	-- Inventories that are marked to not save will not update in the Database, if they inventory is already saved, it will not be deleted when unloaded.
+	-- @realm server
+	-- @treturn[1] bool Returns the field `noSave`.
+	-- @treturn[2] bool Returns true if the field `noSave` is not registered to this inventory.
+	function META:GetShouldSave()
+		return self.noSave or true
+	end
+	
 	--- Add an item to the inventory.
 	-- @realm server
 	-- @param uniqueID The item unique ID (e.g `"handheld_radio"`) or instance ID (e.g `1024`) to add to the inventory

--- a/gamemode/core/meta/sh_inventory.lua
+++ b/gamemode/core/meta/sh_inventory.lua
@@ -560,7 +560,8 @@ if (SERVER) then
 	end
 
 	--- Gets whether or not an `Inventory` should save.
-	-- Inventories that are marked to not save will not update in the Database, if they inventory is already saved, it will not be deleted when unloaded.
+	-- Inventories that are marked to not save will not update in the Database,
+	-- if the inventory is already saved, it will not be deleted when unloaded.
 	-- @realm server
 	-- @treturn[1] bool Returns the field `noSave`.
 	-- @treturn[2] bool Returns true if the field `noSave` is not registered to this inventory.


### PR DESCRIPTION
Despite noSave being a very useful variable for creating easily manipulatable single use inventories, it has no documentation or official way to set the variable, this will add helper functions and document the existence of the variable as a whole.