### PR TITLE
Update IxIconTextEntry to not use hardcoded Icon, adjust style of IxIconTextEntry.

### DIFF
--- a/gamemode/core/derma/cl_generic.lua
+++ b/gamemode/core/derma/cl_generic.lua
@@ -897,27 +897,24 @@ function PANEL:Init()
 end
 
 function PANEL:SetIcon(newIcon)
-	surface.SetFont("ixSmallTitleIcons")
-
-	self.iconWidth, self.iconHeight = surface.GetTextSize(newIcon)
-	self.icon = newIcon
-
-	self:DockMargin(self.iconWidth + 2, 0, 0, 8)
+    surface.SetFont("ixSmallTitleIcons")
+    self.iconWidth, self.iconHeight = surface.GetTextSize(newIcon)
+    self.icon = newIcon
+    self:DockMargin(self.iconWidth + 4, 0, 0, 8)
+    self:SizeToContents()
 end
 
 function PANEL:Paint(width, height)
-	BaseClass.Paint(self, width, height)
-
-	-- there's no inset for text entries so we'll have to get creative
-	DisableClipping(true)
-		surface.SetDrawColor(self:GetBackgroundColor())
-		surface.DrawRect(-self.iconWidth - 2, 0, self.iconWidth + 2, height)
-
-		surface.SetFont("ixSmallTitleIcons")
-		surface.SetTextColor(self.iconColor)
-		surface.SetTextPos(-self.iconWidth, 0)
-		surface.DrawText("V")
-	DisableClipping(false)
+    BaseClass.Paint(self, width, height)
+    -- there's no inset for text entries so we'll have to get creative
+    DisableClipping(true)
+    surface.SetDrawColor(self:GetBackgroundColor())
+    surface.DrawRect(-self.iconWidth - 4, 0, self.iconWidth + 4, height)
+    surface.SetFont("ixSmallTitleIcons")
+    surface.SetTextColor(self.iconColor)
+    surface.SetTextPos(-self.iconWidth - 2, 0)
+    surface.DrawText(self:GetIcon())
+    DisableClipping(false)
 end
 
 vgui.Register("ixIconTextEntry", PANEL, "ixTextEntry")

--- a/gamemode/core/derma/cl_generic.lua
+++ b/gamemode/core/derma/cl_generic.lua
@@ -897,27 +897,27 @@ function PANEL:Init()
 end
 
 function PANEL:SetIcon(newIcon)
-    surface.SetFont("ixSmallTitleIcons")
-	
-    self.iconWidth, self.iconHeight = surface.GetTextSize(newIcon)
-    self.icon = newIcon
-	
-    self:DockMargin(self.iconWidth + 4, 0, 0, 8)
+	surface.SetFont("ixSmallTitleIcons")
+
+	self.iconWidth, self.iconHeight = surface.GetTextSize(newIcon)
+	self.icon = newIcon
+
+	self:DockMargin(self.iconWidth + 4, 0, 0, 8)
 end
 
 function PANEL:Paint(width, height)
-    BaseClass.Paint(self, width, height)
-	
-    -- there's no inset for text entries so we'll have to get creative
-    DisableClipping(true)
-    	surface.SetDrawColor(self:GetBackgroundColor())
-    	surface.DrawRect(-self.iconWidth - 4, 0, self.iconWidth + 4, height)
-	
-    	surface.SetFont("ixSmallTitleIcons")
-    	surface.SetTextColor(self.iconColor)
-    	surface.SetTextPos(-self.iconWidth - 2, 0)
-    	surface.DrawText(self:GetIcon())
-    DisableClipping(false)
+	BaseClass.Paint(self, width, height)
+
+	-- there's no inset for text entries so we'll have to get creative
+	DisableClipping(true)
+		surface.SetDrawColor(self:GetBackgroundColor())
+		surface.DrawRect(-self.iconWidth - 4, 0, self.iconWidth + 4, height)
+
+		surface.SetFont("ixSmallTitleIcons")
+		surface.SetTextColor(self.iconColor)
+		surface.SetTextPos(-self.iconWidth - 2, 0)
+		surface.DrawText(self:GetIcon())
+	DisableClipping(false)
 end
 
 vgui.Register("ixIconTextEntry", PANEL, "ixTextEntry")

--- a/gamemode/core/derma/cl_generic.lua
+++ b/gamemode/core/derma/cl_generic.lua
@@ -901,7 +901,6 @@ function PANEL:SetIcon(newIcon)
     self.iconWidth, self.iconHeight = surface.GetTextSize(newIcon)
     self.icon = newIcon
     self:DockMargin(self.iconWidth + 4, 0, 0, 8)
-    self:SizeToContents()
 end
 
 function PANEL:Paint(width, height)

--- a/gamemode/core/derma/cl_generic.lua
+++ b/gamemode/core/derma/cl_generic.lua
@@ -898,21 +898,25 @@ end
 
 function PANEL:SetIcon(newIcon)
     surface.SetFont("ixSmallTitleIcons")
+	
     self.iconWidth, self.iconHeight = surface.GetTextSize(newIcon)
     self.icon = newIcon
+	
     self:DockMargin(self.iconWidth + 4, 0, 0, 8)
 end
 
 function PANEL:Paint(width, height)
     BaseClass.Paint(self, width, height)
+	
     -- there's no inset for text entries so we'll have to get creative
     DisableClipping(true)
-    surface.SetDrawColor(self:GetBackgroundColor())
-    surface.DrawRect(-self.iconWidth - 4, 0, self.iconWidth + 4, height)
-    surface.SetFont("ixSmallTitleIcons")
-    surface.SetTextColor(self.iconColor)
-    surface.SetTextPos(-self.iconWidth - 2, 0)
-    surface.DrawText(self:GetIcon())
+    	surface.SetDrawColor(self:GetBackgroundColor())
+    	surface.DrawRect(-self.iconWidth - 4, 0, self.iconWidth + 4, height)
+	
+    	surface.SetFont("ixSmallTitleIcons")
+    	surface.SetTextColor(self.iconColor)
+    	surface.SetTextPos(-self.iconWidth - 2, 0)
+    	surface.DrawText(self:GetIcon())
     DisableClipping(false)
 end
 


### PR DESCRIPTION
Fixed IxIconTextEntry being locked to just "V", the 'search icon'. Added 2px spacing to the right of the icon for it to looked more "centered.". I encountered this issue while trying to stylize some text entry boxes, and had to override the panel with literally just a couple lines.

You can preview all of the icons that exist in `IxSmallTitleIcons` by using the following concommand:
```
concommand.Add('ix_iconpreview', function(ply, _, args)
	local ui = vgui.Create('DFrame')
	ui:SetSize(600, 600)
	ui:Center()
	local n = ui:Add('DScrollPanel')
	n:Dock(FILL)
	
	for i=32, 256 do
		local x = n:Add('ixIconTextEntry')
		x:Dock(TOP)
		x:SetIcon(utf8.char(i))
		x:SetText(utf8.char(i))
	end
end)
```

I was originally also going to update it so that it could have it's Icon Font set manually to the medium/big ones, but I unfortunately couldn't find the time for that, maybe someone else will do it if they care enough.