### PR TITLE
Remove the SteamID64 workaround

### DIFF
--- a/gamemode/shared.lua
+++ b/gamemode/shared.lua
@@ -42,17 +42,7 @@ GM.Author = "nebulous.cloud"
 GM.Website = "https://nebulous.cloud"
 GM.Version = "β"
 
--- Fix for client:SteamID64() returning nil when in single-player.
 do
-	local playerMeta = FindMetaTable("Player")
-	playerMeta.ixSteamID64 = playerMeta.ixSteamID64 or playerMeta.SteamID64
-
-	-- Overwrite the normal SteamID64 method.
-	function playerMeta:SteamID64()
-		-- Return 0 if the SteamID64 could not be found.
-		return self:ixSteamID64() or 0
-	end
-
 	-- luacheck: globals player_manager
 	player_manager.ixTranslateModel = player_manager.ixTranslateModel or player_manager.TranslateToPlayerModelName
 


### PR DESCRIPTION
In the next update (scheduled for **June 9**) and currently implemented in the development branches, this issue is fixed.

Sources:
- https://github.com/Facepunch/garrysmod-issues/issues/2614
- https://commits.facepunch.com/381723
- https://docs.google.com/document/u/1/d/e/2PACX-1vTzEJEpdEje8e-FgsbyWGydu_Ez7p82MwOUPmRlUAAJ-KpkNJhHctyadZosfUYjVTz26KGip7bI7M9T/pub