### PR TITLE
Fix death screen not drawing text properly

### DIFF
--- a/gamemode/core/hooks/cl_hooks.lua
+++ b/gamemode/core/hooks/cl_hooks.lua
@@ -659,11 +659,13 @@ function GM:PostDrawOpaqueRenderables(bDepth, bSkybox)
 end
 
 function GM:PostDrawHUD()
-	ix.hud.DrawAll(true)
+	cam.Start2D()
+		ix.hud.DrawAll(true)
 
-	if (!IsValid(ix.gui.characterMenu) or ix.gui.characterMenu:IsClosing()) then
-		ix.bar.DrawAction()
-	end
+		if (!IsValid(ix.gui.characterMenu) or ix.gui.characterMenu:IsClosing()) then
+			ix.bar.DrawAction()
+		end
+	cam.End2D()
 end
 
 function GM:ShouldPopulateEntityInfo(entity)


### PR DESCRIPTION
`ix.hud.DrawDeath` function is being drawn in [PostDrawHUD](https://wiki.facepunch.com/gmod/GM:PostDrawHUD) hook, wich has literally the same issue with drawing anything in it as [PreDrawHUD](https://wiki.facepunch.com/gmod/GM:PreDrawHUD) has.

This 2 lines of code make this:
![death1](https://user-images.githubusercontent.com/51002485/121885084-6871d100-cd1c-11eb-9d53-02d7e5cb700e.png)

Look like this:
![death2](https://user-images.githubusercontent.com/51002485/121885140-76275680-cd1c-11eb-9952-8ae0bdbc2e25.png)