### PR TITLE
Pass data through PlayerMessageSend hook.

### DIFF
--- a/gamemode/core/libs/sh_chatbox.lua
+++ b/gamemode/core/libs/sh_chatbox.lua
@@ -341,7 +341,7 @@ if (SERVER) then
 				text = ix.chat.Format(text)
 			end
 
-			text = hook.Run("PlayerMessageSend", speaker, chatType, text, bAnonymous, receivers, rawText) or text
+			text = hook.Run("PlayerMessageSend", speaker, chatType, text, bAnonymous, receivers, rawText, data) or text
 
 			net.Start("ixChatMessage")
 				net.WriteEntity(speaker)


### PR DESCRIPTION
Was gonna make a plugin that allows specific people to be whitelisted to hear anywhere, but it becomes impossible to replicate a chat message being sent to players if exact data cannot be sent back through the hook.