### PR TITLE
Restore Outfit OnLoadout

### DIFF
--- a/gamemode/items/base/sh_outfit.lua
+++ b/gamemode/items/base/sh_outfit.lua
@@ -302,6 +302,12 @@ function ITEM:OnRemoved()
 	end
 end
 
+function ITEM:OnLoadout()
+	if (self:GetData("equip")) then
+		self:AddOutfit(self.player)
+	end
+end
+
 function ITEM:OnEquipped()
 end
 


### PR DESCRIPTION
lets say bodygroup 1 is set to value 5 when your character is created, now you equip this outfit, you switch characters your bodygroup 1 is back to value 5 now you unequip the item and bodygroup 1 has been saved to the item even though you never changed the bodygroup 1 when the item was equipped

this fixes it by restoring the outfit when switching characters.

weapons get restored this way, pacoutfits get restored in a very similar way, etc..,