### PR TITLE
Fix typing indicator remaining over head or not showing under certain circumstances

### DIFF
--- a/plugins/typing.lua
+++ b/plugins/typing.lua
@@ -225,10 +225,6 @@ else
 	end
 
 	net.Receive("ixTypeClass", function(length, client)
-		if ((client.ixNextTypeClass or 0) > RealTime()) then
-			return
-		end
-
 		local newClass = net.ReadString()
 
 		-- send message to players in pvs only since they're the only ones who can see the indicator
@@ -242,7 +238,5 @@ else
 		else
 			net.SendPVS(client:GetPos())
 		end
-
-		client.ixNextTypeClass = RealTime() + 0.2
 	end)
 end


### PR DESCRIPTION
I think everyone who used Helix after [this](https://github.com/NebulousCloud/helix/commit/538427a413575599f9ff2e7305b3c814eea790f0#diff-14eb6cadb933f06a9aad5f2b38ad71416df90882468befe591008c4e38507589) commit have noticed that under certain circumstances typing indicator over head either remains if player finished typing his message or is not being showed if player started typing something in chat. In videos bellow I'm using original Helix gamemode and HL2 RP schema with only some lines of code in typing plugin being commented so the typing player sees his own indicator.

Indicator reamins:
https://user-images.githubusercontent.com/51002485/126161592-c16aa02d-20ad-44da-83f4-5242ab427979.mp4

Indicator not being showed:
https://user-images.githubusercontent.com/51002485/126161681-e703c2e9-0dec-4858-a8d0-8cdc64895ac6.mp4

Flood with this commit:
https://user-images.githubusercontent.com/51002485/126162284-45bedc7f-ba2a-4228-b7a4-a25c21b84532.mp4

I agree that removing cooldown is not the best solution but I couldn't find any other way to fix this. Reducing cooldown only makes it hard to experience bug but doesn't fix it. If anyone has a better idea I ask to post it here.