### PR TITLE
Remove redundant check in typing plugin

### DIFF
--- a/plugins/typing.lua
+++ b/plugins/typing.lua
@@ -133,10 +133,6 @@ if (CLIENT) then
 			local text = v.ixChatClassText
 			local range = v.ixChatClassRange
 
-			if (!text) then
-				continue
-			end
-
 			local bAnimation = !ix.option.Get("disableAnimations", false)
 			local fraction
 


### PR DESCRIPTION
Literally the same is being checked here:
https://github.com/NebulousCloud/helix/blob/016b0673ff72b4f76d810fe47495f34d986ae446/plugins/typing.lua#L128