### PR TITLE
Add privilege names to currency commands

### DIFF
--- a/gamemode/core/sh_commands.lua
+++ b/gamemode/core/sh_commands.lua
@@ -416,6 +416,7 @@ do
 
 		ix.command.Add("Give" .. MONEY_NAME, {
 			alias = {"GiveMoney"},
+			privilege = "GiveMoney",
 			description = "@cmdGiveMoney",
 			arguments = ix.type.number,
 			OnRun = function(self, client, amount)
@@ -447,6 +448,7 @@ do
 
 		ix.command.Add("CharSet" .. MONEY_NAME, {
 			alias = {"CharSetMoney"},
+			privilege = "CharSetMoney",
 			description = "@cmdCharSetMoney",
 			superAdminOnly = true,
 			arguments = {
@@ -467,6 +469,7 @@ do
 
 		ix.command.Add("Drop" .. MONEY_NAME, {
 			alias = {"DropMoney"},
+			privilege = "DropMoney",
 			description = "@cmdDropMoney",
 			arguments = ix.type.number,
 			OnRun = function(self, client, amount)


### PR DESCRIPTION
This will allow you to have 1 admin mod database across 2 different schemas with different currencies without there being anything weird or confusing going on.

Although it will break your current privileges setup so you'll have to go in and reconfigure that in your admin mod one time only.