### PR TITLE
Improvments to vendors PhysicsObjects and their collision

### DIFF
--- a/plugins/vendor/entities/entities/ix_vendor.lua
+++ b/plugins/vendor/entities/entities/ix_vendor.lua
@@ -21,7 +21,7 @@ function ENT:Initialize()
 		self:DrawShadow(true)
 		self:InitPhysObj()
 
-		self:AddCallback("OnAngleChange", function(entity, newAngles)
+		self:AddCallback("OnAngleChange", function(entity)
 			local mins, maxs = entity:GetAxisAlignedBoundingBox()
 
 			entity:SetCollisionBounds(mins, maxs)

--- a/plugins/vendor/entities/entities/ix_vendor.lua
+++ b/plugins/vendor/entities/entities/ix_vendor.lua
@@ -58,8 +58,8 @@ end
 
 function ENT:GetAxisAlignedBoundingBox()
 	local mins, maxs = self:GetModelBounds()
-	mins, maxs = self:GetRotatedAABB(mins, maxs)
 	mins = Vector(mins.x, mins.y, 0)
+	mins, maxs = self:GetRotatedAABB(mins, maxs)
 
 	return mins, maxs
 end

--- a/plugins/vendor/entities/entities/ix_vendor.lua
+++ b/plugins/vendor/entities/entities/ix_vendor.lua
@@ -19,8 +19,13 @@ function ENT:Initialize()
 		self:SetUseType(SIMPLE_USE)
 		self:SetMoveType(MOVETYPE_NONE)
 		self:DrawShadow(true)
-		self:SetSolid(SOLID_BBOX)
-		self:PhysicsInit(SOLID_BBOX)
+		self:InitPhysObj()
+
+		self:AddCallback("OnAngleChange", function(entity, newAngles)
+			local mins, maxs = entity:GetAxisAlignedBoundingBox()
+
+			entity:SetCollisionBounds(mins, maxs)
+		end)
 
 		self.items = {}
 		self.messages = {}
@@ -31,13 +36,6 @@ function ENT:Initialize()
 		self:SetDescription("")
 
 		self.receivers = {}
-
-		local physObj = self:GetPhysicsObject()
-
-		if (IsValid(physObj)) then
-			physObj:EnableMotion(false)
-			physObj:Sleep()
-		end
 	end
 
 	timer.Simple(1, function()
@@ -45,6 +43,26 @@ function ENT:Initialize()
 			self:SetAnim()
 		end
 	end)
+end
+
+function ENT:InitPhysObj()
+	local mins, maxs = self:GetAxisAlignedBoundingBox()
+	local bPhysObjCreated = self:PhysicsInitBox(mins, maxs)
+
+	if (bPhysObjCreated) then
+		self:SetMoveType(MOVETYPE_NONE)
+
+		local physObj = self:GetPhysicsObject()
+		physObj:EnableMotion(false)
+		physObj:Sleep()
+	end
+end
+
+function ENT:GetAxisAlignedBoundingBox()
+	local mins, maxs = self:GetModelBounds()
+	mins, maxs = self:GetRotatedAABB(mins, maxs)
+
+	return mins, maxs
 end
 
 function ENT:CanAccess(client)

--- a/plugins/vendor/entities/entities/ix_vendor.lua
+++ b/plugins/vendor/entities/entities/ix_vendor.lua
@@ -50,8 +50,6 @@ function ENT:InitPhysObj()
 	local bPhysObjCreated = self:PhysicsInitBox(mins, maxs)
 
 	if (bPhysObjCreated) then
-		self:SetMoveType(MOVETYPE_NONE)
-
 		local physObj = self:GetPhysicsObject()
 		physObj:EnableMotion(false)
 		physObj:Sleep()
@@ -61,6 +59,7 @@ end
 function ENT:GetAxisAlignedBoundingBox()
 	local mins, maxs = self:GetModelBounds()
 	mins, maxs = self:GetRotatedAABB(mins, maxs)
+	mins = Vector(mins.x, mins.y, 0)
 
 	return mins, maxs
 end

--- a/plugins/vendor/sh_plugin.lua
+++ b/plugins/vendor/sh_plugin.lua
@@ -86,15 +86,7 @@ if (SERVER) then
 
 			entity:SetModel(v.model)
 			entity:SetSkin(v.skin or 0)
-			entity:SetSolid(SOLID_BBOX)
-			entity:PhysicsInit(SOLID_BBOX)
-
-			local physObj = entity:GetPhysicsObject()
-
-			if (IsValid(physObj)) then
-				physObj:EnableMotion(false)
-				physObj:Sleep()
-			end
+			entity:InitPhysObj()
 
 			entity:SetNoBubble(v.bubble)
 			entity:SetDisplayName(v.name)
@@ -275,8 +267,7 @@ if (SERVER) then
 			data = {uniqueID, entity.classes[uniqueID]}
 		elseif (key == "model") then
 			entity:SetModel(data)
-			entity:SetSolid(SOLID_BBOX)
-			entity:PhysicsInit(SOLID_BBOX)
+			entity:InitPhysObj()
 			entity:SetAnim()
 		elseif (key == "useMoney") then
 			if (entity.money) then


### PR DESCRIPTION
Calling `PhysicsInit` while trying to create `PhysicsObject` ends with it having invalid AABB if model is `prop_ragdoll`, despite the entity itself having the valid ones. The result is simple - weird behaviour of vendors when they are being unfreezed and, for example, being knocked over.

The way to fix it is to use `PhysicsInitBox` instead of `PhysicsInit`, which adds another issue with bounding boxes being to big ignore the fact that they are remaining same even if entities angle is being changed. For example, you can just bump into invisible collision if vendor is 'lying' on a ground.

And this is where `AddCallback` and `OnAngleChange` come in, providing ability to change vendors collision bounds when angles is being changed.

As addition I want to mention, that currently, after changing vendors model, under certain circumstances you can unconsciously "unfreeze" vendor, because `EnableMotion` and `Sleep` is not being called after creating new `PhysicsObject`.

I think everyone noticed this oddities with vendors and understand what I'm talking about, but if not, I can provide some screenshots of current problems and my fixes working fine.