### PR TITLE
Allows use of materials for inventory icons

### DIFF
--- a/gamemode/core/derma/cl_inventory.lua
+++ b/gamemode/core/derma/cl_inventory.lua
@@ -677,6 +677,7 @@ function PANEL:AddIcon(model, x, y, w, h, skin)
 						itemTable.width,
 						itemTable.height,
 						itemTable:GetModel(),
+						itemTable.material,
 						itemTable.iconCam
 					)
 				end

--- a/gamemode/core/libs/thirdparty/cl_ikon.lua
+++ b/gamemode/core/libs/thirdparty/cl_ikon.lua
@@ -247,7 +247,7 @@ end
 	Renders the Icon with given arguments.
 	returns nothing
 ]]--
-function ikon:renderIcon(name, w, h, mdl, camInfo, updateCache)
+function ikon:renderIcon(name, w, h, mdl, material, camInfo, updateCache)
 	if (#ikon.requestList > 0) then return IKON_BUSY end
 	if (ikon.requestList[name]) then return IKON_PROCESSING end
 	if (!w or !h or !mdl) then return IKON_SOMETHINGWRONG end
@@ -256,6 +256,7 @@ function ikon:renderIcon(name, w, h, mdl, camInfo, updateCache)
 	ikon.curWidth = w or 1
 	ikon.curHeight = h or 1
 	ikon.renderModel = mdl
+	ikon.renderMaterial = material or ""
 
 	if (camInfo) then
 		ikon.info = camInfo
@@ -272,6 +273,7 @@ function ikon:renderIcon(name, w, h, mdl, camInfo, updateCache)
 	end
 
 	ikon.renderEntity:SetModel(ikon.renderModel)
+	ikon.renderEntity:SetMaterial(ikon.renderMaterial)
 
 	local bone = ikon.renderEntity:LookupBone("ValveBiped.Bip01_Head1")
 

--- a/gamemode/core/meta/sh_item.lua
+++ b/gamemode/core/meta/sh_item.lua
@@ -228,8 +228,11 @@ function ITEM:GetSkin()
 	return self.skin or 0
 end
 
+--- Returns the material of the item.
+-- @realm shared
+-- @treturn string The material of the item
 function ITEM:GetMaterial()
-	return nil
+	return self.material or ""
 end
 
 --- Returns the ID of the owning character, if one exists.


### PR DESCRIPTION
Let's us use materials for inventory icons by adding these two lines
`ITEM.exRender = true // Required to enable extended icon rendering`
`ITEM.material = "models/props_junk/ravenholmsign_sheet" // Any material string really`

And can turns boring icons to cool looking ones
![hl2_JN2n00vcae](https://user-images.githubusercontent.com/41900703/133990961-e695a3ae-0ac5-4b6c-b1a7-333d6d8ab11c.png) ![hl2_fi1pumJzYM](https://user-images.githubusercontent.com/41900703/133990972-0058188f-c8e2-4fb1-bcc8-463b34190523.png)

Yet I discovered a weird bug, that occurs when we are flushing icons with **ix_flushicon** and render them again by opening inventory:

Icons on the left **before flush** and icons on the right are **post-flush**
![hl2_82ErZxPNDR](https://user-images.githubusercontent.com/41900703/133991501-84c42ce6-c3c6-441c-a063-02340f44beae.png) ![hl2_AB7jqy1Ds4](https://user-images.githubusercontent.com/41900703/133991572-e9a7bf79-ca2e-4bf9-9601-0b745cef26bc.png)

Yet newly rendered icons are perfectly fine in folder, it's just something that happens with [Material()](https://wiki.facepunch.com/gmod/Global.Material) function of gmod and it's not the problem of me using SetMaterial while rendering icons (I tried flushing icons just with the items having exRender enabled).
![explorer_c3grEzy7tF](https://user-images.githubusercontent.com/41900703/133991847-4f77a040-2093-4cda-a8ee-a541a5b4dcc9.png)

Further attempts shown that using **ix_flushicon** 5-10 times eventually fixes icons back to normal. Adding new png params in [Material()](https://wiki.facepunch.com/gmod/Global.Material) at this problematic **[line](https://github.com/NebulousCloud/helix/blob/ff41fe48126b891b6484acc3622dee83cf18e824/gamemode/core/libs/thirdparty/cl_ikon.lua#L328)** also helps, but icons still turn to shit again with next **ix_flushicon**.