### PR TITLE
Fix item instance's metatable object reference is not updated when gamemode refreshed.

### DIFF
--- a/gamemode/core/libs/sh_item.lua
+++ b/gamemode/core/libs/sh_item.lua
@@ -239,7 +239,7 @@ function ix.item.Register(uniqueID, baseID, isBaseItem, path, luaGenerated)
 				-- we don't know which item was actually edited, so we'll refresh all of them
 				for _, v in pairs(ix.item.instances) do
 					if (v.uniqueID == uniqueID) then
-						table.Merge(v, ITEM)
+						ix.util.MetatableSafeTableMerge(v, ITEM)
 					end
 				end
 			end

--- a/gamemode/core/sh_util.lua
+++ b/gamemode/core/sh_util.lua
@@ -1143,8 +1143,8 @@ end
 --- Merges the contents of the second table with the content in the first one. The destination table will be modified.
 --- If element is table but not metatable object, value's elements will be changed only.
 -- @realm shared
--- @table destination The table you want the source table to merge with
--- @table source The table you want to merge with the destination table
+-- @tab destination The table you want the source table to merge with
+-- @tab source The table you want to merge with the destination table
 -- @return table
 function ix.util.MetatableSafeTableMerge(destination, source)
 	for k, v in pairs(source) do
@@ -1156,7 +1156,6 @@ function ix.util.MetatableSafeTableMerge(destination, source)
 			destination[ k ] = v;
 		end
 	end
-	
 	return destination;
 end
 

--- a/gamemode/core/sh_util.lua
+++ b/gamemode/core/sh_util.lua
@@ -1151,7 +1151,7 @@ function ix.util.MetatableSafeTableMerge(destination, source)
 		if (istable(v) and istable(destination[k]) and getmetatable(v) == nil) then
 			-- don't overwrite one table with another
 			-- instead merge them recurisvely
-			ix.util.MetatableSafetyMerge(destination[k], v);
+			ix.util.MetatableSafeTableMerge(destination[k], v);
 		else
 			destination[ k ] = v;
 		end

--- a/gamemode/core/sh_util.lua
+++ b/gamemode/core/sh_util.lua
@@ -1140,5 +1140,25 @@ function ix.util.EmitQueuedSounds(entity, sounds, delay, spacing, volume, pitch)
 	return delay
 end
 
+--- Merges the contents of the second table with the content in the first one. The destination table will be modified.
+--- If element is table but not metatable object, value's elements will be changed only.
+-- @realm shared
+-- @table destination The table you want the source table to merge with
+-- @table source The table you want to merge with the destination table
+-- @return table
+function ix.util.MetatableSafeTableMerge(destination, source)
+	for k, v in pairs(source) do
+		if (istable(v) and istable(destination[k]) and getmetatable(v) == nil) then
+			-- don't overwrite one table with another
+			-- instead merge them recurisvely
+			ix.util.MetatableSafetyMerge(destination[k], v);
+		else
+			destination[ k ] = v;
+		end
+	end
+	
+	return destination;
+end
+
 ix.util.Include("helix/gamemode/core/meta/sh_entity.lua")
 ix.util.Include("helix/gamemode/core/meta/sh_player.lua")


### PR DESCRIPTION
# Summary
[`table.Merge`](https://github.com/Facepunch/garrysmod/blob/master/garrysmod/lua/includes/extensions/table.lua#L81-L95) function's merging is if element is table, replacing table's element.
```lua
function table.Merge( dest, source )

	for k, v in pairs( source ) do
		if ( istable( v ) && istable( dest[ k ] ) ) then
			-- don't overwrite one table with another
			-- instead merge them recurisvely
			table.Merge( dest[ k ], v )
		else
			dest[ k ] = v
		end
	end

	return dest

end
```

Unfortunately, `table.Merge` function is not include metatable object case. (metatable is kind of table.) This means that the metatable reference of the table's metatable object does not change, only the value of the object changes.

Therefore, the following problem occurs when the gamemode is refreshed.
```lua
for _, v in pairs(ix.item.instances) do
  if (v.uniqueID == uniqueID) then
    table.Merge(v, ITEM);
    -- It will be trigger assertion failure.
    assert(getmetatable(v.somemetatableobject) == getmetatable(ITEM.somemetatableobject));
  end
end
```
This code is part of [sh_item.lua](https://github.com/NebulousCloud/helix/blob/master/gamemode/core/libs/sh_item.lua#L240-L244).

# Changes
A new table merge function (`ix.util.MetatableSafeTableMerge`) with exception handling for metatable objects has been added to the ix.util table and replaced the table.Merge function in sh_item.lua.

# Alternative
## New hooks for item table
Add an "OnGamemodeReloaded" hook (or similar) to give the items table responsibility for updating metatable objects. This make problem of having to implement code to update object refresh in item table code when using metatable objects.

## Edit the document
Just write 'if metatable object in the field of the item table, the object's metatable reference will not change when gamemode refresh.' to the documentation. This is the easiest and fastest way.
