### PR TITLE
Fix CharacterLoaded realm documentation

### DIFF
--- a/docs/hooks/plugin.lua
+++ b/docs/hooks/plugin.lua
@@ -339,7 +339,7 @@ end
 function CharacterHasFlags(self, flags)
 end
 
---- @realm server
+--- @realm shared
 function CharacterLoaded(character)
 end
 


### PR DESCRIPTION
Just a small correction to the hook documentation, CharacterLoaded gets called on both the client and the server.
```lua
function PLUGIN:CharacterLoaded(character)
    print(character)
end
```
![image](https://user-images.githubusercontent.com/36643731/143162316-1451dae8-3a83-49d8-b5c5-6e4c898dfbf8.png)
