### PR TITLE
Fix issue with 'ix_schema' table.

### DIFF
--- a/gamemode/core/libs/sv_database.lua
+++ b/gamemode/core/libs/sv_database.lua
@@ -57,6 +57,7 @@ function ix.db.InsertSchema(schemaType, field, fieldType)
 
 		local query = mysql:Update("ix_schema")
 			query:Update("columns", util.TableToJSON(schema))
+			query:Where("table", schemaType)
 		query:Execute()
 
 		query = mysql:Alter(schemaType)


### PR DESCRIPTION
Currently every Row in ix_schema table is updated, this causes issues if you have more than the default one 'ix_characters' row. As updating every row then next restart adds unnecessary columns to each table. Doing a simple 'Where' clause fixes this issue.

Before Fix:
https://i.imgur.com/Q6OB3KN.png

After Fix:
https://i.imgur.com/kgDHzGA.png