### PR TITLE
Fix ixSettingsRowColor "color" field not having Color metatable

### DIFF
--- a/gamemode/core/derma/cl_settings.lua
+++ b/gamemode/core/derma/cl_settings.lua
@@ -53,6 +53,7 @@ function PANEL:OpenPicker()
 
 	self.picker.OnValueChanged = function(panel)
 		local newColor = panel:GetValue()
+		newColor = Color(newColor.r, newColor.g, newColor.b, newColor.a)
 
 		if (newColor != self.color) then
 			self.color = newColor


### PR DESCRIPTION
`DColorPalette`'s `OnValueChanged` function returns color without metatable as can be seen on [wiki page](https://wiki.facepunch.com/gmod/DColorPalette:OnValueChanged).
Made this commit due to this issue being marked as bug in `DColorMix` `ValueChanged` function on [wiki](https://wiki.facepunch.com/gmod/DColorMixer:ValueChanged).