### PR TITLE
Add CanPlayerCombineItem hook

### DIFF
--- a/docs/hooks/plugin.lua
+++ b/docs/hooks/plugin.lua
@@ -99,6 +99,22 @@ end
 function CanPlayerAccessDoor(client, door, access)
 end
 
+--- Whether or not a player is allowed to combine an item `other` into the given `item`.
+-- @realm server
+-- @player client Player attempting to combine an item into another
+-- @number item instance ID of the item being dropped onto
+-- @number other instance ID of the item being combined into the first item, this can be invalid due to it being from clientside
+-- @treturn bool Whether or not to allow the player to combine the items
+-- @usage function PLUGIN:CanPlayerCombineItem(client, item, other)
+--		local otherItem = ix.item.instances[other]
+--
+--		if (otherItem and otherItem.uniqueID == "soda") then
+--			return false -- disallow combining any item that has a uniqueID equal to `soda`
+--		end
+--	end
+function CanPlayerCombineItem(client, item, other)
+end
+
 --- Whether or not a player is allowed to create a new character with the given payload.
 -- @realm server
 -- @player client Player attempting to create a new character

--- a/gamemode/core/hooks/sv_hooks.lua
+++ b/gamemode/core/hooks/sv_hooks.lua
@@ -138,7 +138,7 @@ function GM:KeyRelease(client, key)
 	end
 end
 
-function GM:CanPlayerInteractItem(client, action, item)
+function GM:CanPlayerInteractItem(client, action, item, data)
 	if (client:IsRestricted()) then
 		return false
 	end
@@ -156,6 +156,26 @@ function GM:CanPlayerInteractItem(client, action, item)
 		return false
 	end
 
+	if (action == "combine") then
+		local other = data[1]
+
+		if (hook.Run("CanPlayerCombineItem", client, item, other) == false) then
+			return false
+		end
+
+		local combineItem = ix.item.instances[other]
+
+		if (combineItem and combineItem.invID != 0) then
+			local combineInv = ix.item.inventories[combineItem.invID]
+
+			if (!combineInv:OnCheckAccess(client)) then
+				return false
+			end
+		else
+			return false
+		end
+	end
+
 	if (isentity(item) and item.ixSteamID and item.ixCharID
 	and item.ixSteamID == client:SteamID() and item.ixCharID != client:GetCharacter():GetID()
 	and !item:GetItemTable().bAllowMultiCharacterInteraction) then
@@ -171,6 +191,10 @@ function GM:CanPlayerDropItem(client, item)
 end
 
 function GM:CanPlayerTakeItem(client, item)
+
+end
+
+function GM:CanPlayerCombineItem(client, item, other)
 
 end
 

--- a/gamemode/items/base/sh_bags.lua
+++ b/gamemode/items/base/sh_bags.lua
@@ -56,7 +56,7 @@ ITEM.functions.View = {
 }
 ITEM.functions.combine = {
 	OnRun = function(item, data)
-		ix.item.instances[data[1]]:Transfer(item:GetData("id"))
+		ix.item.instances[data[1]]:Transfer(item:GetData("id"), nil, nil, item.player)
 
 		return false
 	end,


### PR DESCRIPTION
Currently combine item does not check if the player owns the second item, this is a very big problem.
This will fix it by checking if the player has access to the inventory containing the second item.

Also adds hook `CanPlayerCombineItem` and documentation.