### PR TITLE
Fix paired scenes not saving.

### DIFF
--- a/plugins/mapscene.lua
+++ b/plugins/mapscene.lua
@@ -184,7 +184,7 @@ else
 
 		if (position2) then
 			data = {position2, angles, angles2}
-			self.scenes[position] = data
+			self.scenes[#self.scenes + 1] = data
 
 			net.Start("ixMapSceneAddPair")
 				net.WriteTable(data)


### PR DESCRIPTION
Currently paired map scenes are being stored with the position set as key in the scenes table, this leads to them not saving.