### PR TITLE
Use SteamID instead of UniqueID in DoStaredAction and SetAction functions

### DIFF
--- a/gamemode/core/meta/sh_player.lua
+++ b/gamemode/core/meta/sh_player.lua
@@ -130,7 +130,7 @@ end
 -- end)
 -- -- prints "hello!" after looking at the entity for 4 seconds
 function meta:DoStaredAction(entity, callback, time, onCancel, distance)
-	local uniqueID = "ixStare"..self:UniqueID()
+	local uniqueID = "ixStare" .. self:SteamID()
 	local data = {}
 	data.filter = self
 
@@ -285,7 +285,7 @@ if (SERVER) then
 		finishTime = finishTime or (startTime + time)
 
 		if (text == false) then
-			timer.Remove("ixAct"..self:UniqueID())
+			timer.Remove("ixAct" .. self:SteamID())
 
 			net.Start("ixActionBarReset")
 			net.Send(self)
@@ -307,7 +307,7 @@ if (SERVER) then
 		-- If we have provided a callback, run it delayed.
 		if (callback) then
 			-- Create a timer that runs once with a delay.
-			timer.Create("ixAct"..self:UniqueID(), time, 1, function()
+			timer.Create("ixAct" .. self:SteamID(), time, 1, function()
 				-- Call the callback if the player is still valid.
 				if (IsValid(self)) then
 					callback(self)


### PR DESCRIPTION
According to the wiki, [Player:UniqueID](https://wiki.facepunch.com/gmod/Player:UniqueID) is deprecated and not guaranteed to be unique. So it's rellay necessary to use [Player:SteamID](https://wiki.facepunch.com/gmod/Player:SteamID) or simmilar functions, like it's done in `SetRagdolled` function:
https://github.com/NebulousCloud/helix/blob/2ee383b6779daee5e4f44deb7b1424a91e9c46f6/gamemode/core/meta/sh_player.lua#L560