### PR TITLE
Account for characters without an inventory

### DIFF
--- a/gamemode/core/meta/sh_item.lua
+++ b/gamemode/core/meta/sh_item.lua
@@ -308,7 +308,7 @@ function ITEM:GetOwner()
 	for _, v in ipairs(player.GetAll()) do
 		local character = v:GetCharacter()
 
-		if (character and character:GetInventory():GetItemByID(id)) then
+		if (character and character:GetInventory() and character:GetInventory():GetItemByID(id)) then
 			return v
 		end
 	end


### PR DESCRIPTION
Account for characters, such as NPC's, who have a character but not an inventory, this causes an index nil error.