### PR TITLE
Fix a bug with leaving sequences

### DIFF
--- a/gamemode/core/libs/sh_anims.lua
+++ b/gamemode/core/libs/sh_anims.lua
@@ -478,7 +478,12 @@ if (SERVER) then
 
 		self:SetNetVar("canShoot", self.ixCouldShoot)
 		self:SetNetVar("forcedSequence", nil)
-		self:SetMoveType(MOVETYPE_WALK)
+		
+		if (self:GetMoveType() != MOVETYPE_NOCLIP) then
+			self:SetMoveType(MOVETYPE_WALK)
+			
+		end
+		
 		self.ixCouldShoot = nil
 
 		if (self.ixSeqCallback) then


### PR DESCRIPTION
Fixed a bug that caused players to be sent out of observer mode whenever client:LeaveSequence() is called.