### PR TITLE
Add phrase and description in ix.option.Add()

### DIFF
--- a/gamemode/core/libs/sh_option.lua
+++ b/gamemode/core/libs/sh_option.lua
@@ -93,8 +93,8 @@ function ix.option.Add(key, optionType, default, data)
 	-- 	end
 	ix.option.stored[key] = {
 		key = key,
-		phrase = "opt" .. upperName,
-		description = "optd" .. upperName,
+		phrase = data.phrase or "opt" .. upperName,
+		description = data.description or "optd" .. upperName,
 		type = optionType,
 		default = default,
 		min = data.min or 0,


### PR DESCRIPTION
https://docs.gethelix.co/libraries/ix.option/#OptionStructure states you can set the phrase and description via the OptionStructure. This allows that functionality, so you don't need to define it within a language file. Testing yielded positive results.