### PR TITLE
Update cl_tooltip.lua

### DIFF
--- a/gamemode/core/derma/cl_tooltip.lua
+++ b/gamemode/core/derma/cl_tooltip.lua
@@ -296,7 +296,7 @@ function PANEL:PaintUnder(width, height)
 end
 
 function PANEL:Paint(width, height)
-	self:PaintUnder()
+	self:PaintUnder(width, height)
 
 	-- directional arrow
 	self.bRaised = LocalPlayer():IsWepRaised()


### PR DESCRIPTION
When PaintUnder is reassigned it is called with no arguments.
(example: tooltip.PaintUnder = function(self, w, h) ... end will cause argument error)