### PR TITLE
Fixing ForceSequence speed due to players velocity

### DIFF
--- a/gamemode/core/libs/sh_anims.lua
+++ b/gamemode/core/libs/sh_anims.lua
@@ -422,7 +422,8 @@ if (SERVER) then
 	-- @see LeaveSequence
 	function playerMeta:ForceSequence(sequence, callback, time, bNoFreeze)
 		hook.Run("PlayerEnterSequence", self, sequence, callback, time, bNoFreeze)
-
+		self:SetLocalVelocity(Vector(0,0,0))
+		
 		if (!sequence) then
 			net.Start("ixSequenceReset")
 				net.WriteEntity(self)


### PR DESCRIPTION
Fixes animation speed. Due to players velocity, the animation would play at that given speed, they would be speed up