### PR TITLE
Fix sh_item.lua ITEM:Remove() client

### DIFF
--- a/gamemode/core/meta/sh_item.lua
+++ b/gamemode/core/meta/sh_item.lua
@@ -442,6 +442,7 @@ function ITEM:Remove(bNoReplication, bNoDelete)
 			for _, v in pairs(items) do
 				if (v.invID == inv:GetID()) then
 					for x = self.gridX, self.gridX + (self.width - 1) do
+						inv.slots[x]={}
 						for y = self.gridY, self.gridY + (self.height - 1) do
 							inv.slots[x][y] = v.id
 						end


### PR DESCRIPTION
Found an issue where using ITEM:Remove() inside a item.function and not returning value make the item try to delete twice, causing an error on line 446/447 : `inv.slots[x][y] = v.id` where it try to index nil value and crash the whole inventory (client side only) .

This add could fix this error.