### PR TITLE
escCloseMenu option

### DIFF
--- a/gamemode/config/sh_options.lua
+++ b/gamemode/config/sh_options.lua
@@ -43,6 +43,10 @@ if (CLIENT) then
 	ix.option.Add("showIntro", ix.type.bool, true, {
 		category = "general"
 	})
+
+	ix.option.Add("escCloseMenu", ix.type.bool, false, {
+		category = "general"
+	})
 end
 
 ix.option.Add("language", ix.type.array, ix.config.language or "english", {

--- a/gamemode/core/derma/cl_menu.lua
+++ b/gamemode/core/derma/cl_menu.lua
@@ -386,6 +386,10 @@ function PANEL:Think()
 
 	if ((!self.anchorMode and !bTabDown) or gui.IsGameUIVisible()) then
 		self:Remove()
+
+		if (ix.option.Get("escCloseMenu", false)) then
+			gui.HideGameUI()
+		end
 	end
 end
 

--- a/gamemode/languages/sh_english.lua
+++ b/gamemode/languages/sh_english.lua
@@ -387,6 +387,8 @@ LANGUAGE = {
 	optdChatFontScale = "How much bigger or smaller the chat font should be.",
 	optChatOutline = "Outline chat text",
 	optdChatOutline = "Draws an outline around the chat text, rather than a drop shadow. Enable this if you are having trouble reading text.",
+	optEscCloseMenu = "Escape returns to game",
+	optdEscCloseMenu = "Whether the escape menu should close itself when you're using it to close the in-game menu.",
 
 	cmdRoll = "Rolls a number between 0 and the specified number.",
 	cmdPM = "Sends a private message to someone.",


### PR DESCRIPTION
New option that lets you automatically close the game UI when exiting the tab menu with escape. Defaults to off to avoid changing established behavior.