### PR TITLE
Improve plugin config UI

### DIFF
--- a/gamemode/core/derma/cl_config.lua
+++ b/gamemode/core/derma/cl_config.lua
@@ -184,6 +184,7 @@ function PANEL:UpdateUnloaded(bNoSizeToContents)
 		end
 
 		local row = self:AddRow(ix.type.bool, self.unloadedCategory)
+		row.id = k
 
 		row.setting:SetEnabledText(L("on"):utf8upper())
 		row.setting:SetDisabledText(L("off"):utf8upper())

--- a/gamemode/core/derma/cl_config.lua
+++ b/gamemode/core/derma/cl_config.lua
@@ -177,15 +177,20 @@ function PANEL:UpdateUnloaded(bNoSizeToContents)
 		end
 	end
 
-	for k, _ in SortedPairs(ix.plugin.unloaded) do
+	for k, v in SortedPairs(ix.plugin.unloaded) do
 		if (ix.plugin.list[k]) then
 			-- if this plugin is in the loaded plugins list then it's queued for an unload - don't display it in this category
 			continue
 		end
 
 		local row = self:AddRow(ix.type.bool, self.unloadedCategory)
+
+		row.setting:SetEnabledText(L("on"):utf8upper())
+		row.setting:SetDisabledText(L("off"):utf8upper())
+		row.setting:SizeToContents()
+
 		row:SetText(k)
-		row:SetValue(false, true)
+		row:SetValue(!v, true)
 
 		row.OnValueChanged = function(panel, bEnabled)
 			self:OnPluginToggled(k, bEnabled)

--- a/gamemode/core/libs/sh_plugin.lua
+++ b/gamemode/core/libs/sh_plugin.lua
@@ -244,7 +244,9 @@ function ix.plugin.LoadEntities(path)
 end
 
 function ix.plugin.Initialize()
-	ix.plugin.unloaded = ix.data.Get("unloaded", {}, true, true)
+	if SERVER then
+		ix.plugin.unloaded = ix.data.Get("unloaded", {}, true, true)
+	end
 
 	ix.plugin.LoadFromDir("helix/plugins")
 

--- a/gamemode/core/libs/sh_plugin.lua
+++ b/gamemode/core/libs/sh_plugin.lua
@@ -281,7 +281,7 @@ function ix.plugin.SetUnloaded(uniqueID, state, bNoSave)
 
 		ix.plugin.unloaded[uniqueID] = true
 	elseif (ix.plugin.unloaded[uniqueID]) then
-		ix.plugin.unloaded[uniqueID] = nil
+		ix.plugin.unloaded[uniqueID] = false
 	else
 		return false
 	end

--- a/gamemode/core/sh_config.lua
+++ b/gamemode/core/sh_config.lua
@@ -332,7 +332,7 @@ else
 		local bEnabled = net.ReadBool()
 
 		if (bEnabled) then
-			ix.plugin.unloaded[uniqueID] = nil
+			ix.plugin.unloaded[uniqueID] = false
 		else
 			ix.plugin.unloaded[uniqueID] = true
 		end


### PR DESCRIPTION
Just a few minor fixes/bits of polish

- Updated the checkbox text to be consistent between the loaded and unloaded lists (ON/OFF instead of YES/NO for the unloaded list)
- Unloaded plugins that are queued for loading no longer disappear from the unloaded list
- Autorefresh no longer breaks the unloaded plugins list on the client

The ix.plugin.unloaded list changes don't impact how they're stored in data as that's handled separately.