### PR TITLE
Clientside autocomplete for ix concommands

### DIFF
--- a/gamemode/core/libs/sh_command.lua
+++ b/gamemode/core/libs/sh_command.lua
@@ -617,4 +617,27 @@ else
 
 		net.SendToServer()
 	end
+
+	concommand.Add("ix", function(client, _, arguments)
+		ix.command.Send(table.remove(arguments, 1), unpack(arguments))
+	end, function(_, arguments)
+		arguments = arguments:TrimLeft()
+
+		local autocomplete = {}
+		local command = string.Explode(" ", arguments)[1]
+
+		for _, v in pairs(ix.command.FindAll(command, true, true)) do
+			if (arguments:find(v.uniqueID, 1, true) == 1) then
+				return {
+					"ix " .. arguments,
+					v:GetDescription(),
+					L("syntax", v.syntax)
+				}
+			end
+
+			table.insert(autocomplete, "ix " .. v.uniqueID)
+		end
+
+		return autocomplete
+	end)
 end

--- a/gamemode/core/libs/sh_command.lua
+++ b/gamemode/core/libs/sh_command.lua
@@ -627,6 +627,10 @@ else
 		local command = string.Explode(" ", arguments)[1]
 
 		for _, v in pairs(ix.command.FindAll(command, true, true)) do
+			if (v.OnCheckAccess and !v:OnCheckAccess(LocalPlayer())) then
+				continue
+			end
+
 			if (arguments:find(v.uniqueID, 1, true) == 1) then
 				return {
 					"ix " .. arguments,

--- a/gamemode/languages/sh_english.lua
+++ b/gamemode/languages/sh_english.lua
@@ -311,6 +311,7 @@ LANGUAGE = {
 	passwordAttemptLimit = "You have made too many incorrect password attempts!",
 	respawning = "Respawning...",
 	tellAdmin = "Inform a staff member of this error: %s",
+	syntax = "Syntax: %s",
 
 	mapAdd = "You have added a map scene.",
 	mapDel = "You have removed %d map scene(s).",


### PR DESCRIPTION
Adds a clientside concommand for `ix` to handle basic autocompletion

![2023-07-24_22-26-16](https://github.com/NebulousCloud/helix/assets/1381265/3385c960-350c-4bfb-b869-b3fac486d6df)
![2023-07-24_22-36-15](https://github.com/NebulousCloud/helix/assets/1381265/7745c55e-75d5-4c87-8a82-39cf31e727c2)
![2023-07-24_22-26-29](https://github.com/NebulousCloud/helix/assets/1381265/ba8a0262-dd3d-4f7a-a0e2-a7706d424b30)

Something to note is that because we can't have both clientside command/autofill and serverside execution this'll route every command through `ix.command.Send`, causing them to be affected by the ixNextCmd cooldown whereas direct `ix` commands weren't previously.
