### PR TITLE
Remove the SteamID64 workaround

### DIFF
--- a/gamemode/shared.lua
+++ b/gamemode/shared.lua
@@ -42,17 +42,7 @@ GM.Author = "nebulous.cloud"
 GM.Website = "https://nebulous.cloud"
 GM.Version = "β"
 
--- Fix for client:SteamID64() returning nil when in single-player.
 do
-	local playerMeta = FindMetaTable("Player")
-	playerMeta.ixSteamID64 = playerMeta.ixSteamID64 or playerMeta.SteamID64
-
-	-- Overwrite the normal SteamID64 method.
-	function playerMeta:SteamID64()
-		-- Return 0 if the SteamID64 could not be found.
-		return self:ixSteamID64() or 0
-	end
-
 	-- luacheck: globals player_manager
 	player_manager.ixTranslateModel = player_manager.ixTranslateModel or player_manager.TranslateToPlayerModelName
 


### PR DESCRIPTION
This pull request is basically inherited from #321, but this time this function will always return a value whatever the situation (even in a `-multirun` environment) since yesterday's last update:
- https://store.steampowered.com/news/app/4000/view/3664293140704541926
- https://wiki.facepunch.com/gmod/Player:SteamID64~diff:551389
- https://wiki.facepunch.com/gmod/Player:AccountID~diff:551390

I did some testing with these changes and didn't see any issues as everything is now done internally by Garry's Mod, so it's pretty much a transparent change.