### PR TITLE
Add IsValid check to a NULL IGModAudioChannel

### DIFF
--- a/gamemode/core/derma/cl_character.lua
+++ b/gamemode/core/derma/cl_character.lua
@@ -532,7 +532,7 @@ function PANEL:PaintOver(width, height)
 end
 
 function PANEL:OnRemove()
-	if (self.channel) then
+	if (IsValid(self.channel)) then
 		self.channel:Stop()
 		self.channel = nil
 	end


### PR DESCRIPTION
Sometimes IGModAudioChannel can be NULL so this can cause errors and bugs.