### PR TITLE
Fix problem with derived items having isBase true

### DIFF
--- a/gamemode/core/libs/sh_item.lua
+++ b/gamemode/core/libs/sh_item.lua
@@ -129,7 +129,7 @@ function ix.item.Register(uniqueID, baseID, isBaseItem, path, luaGenerated)
 		ITEM = (isBaseItem and ix.item.base or ix.item.list)[uniqueID] or setmetatable({}, meta)
 			ITEM.uniqueID = uniqueID
 			ITEM.base = baseID or ITEM.base
-			ITEM.isBase = isBaseItem
+			ITEM.isBase = isBaseItem or false
 			ITEM.hooks = ITEM.hooks or {}
 			ITEM.postHooks = ITEM.postHooks or {}
 			ITEM.functions = ITEM.functions or {}


### PR DESCRIPTION
Items that aren't bases which have a base, will have isBase set because isBase will be `nil` unless specified otherwise.
With this I make sure they receive a value, which would be false, which is different than nil therefore it won't get set in derived items.

https://github.com/NebulousCloud/helix/blob/c711869b471f843f6138ac4d0545d9773c7e5c00/gamemode/core/libs/sh_item.lua#L188
This is the line which sets item properties if they're nil.