### PR TITLE
Vendor buy net validation

### DIFF
--- a/plugins/vendor/sh_plugin.lua
+++ b/plugins/vendor/sh_plugin.lua
@@ -403,6 +403,10 @@ if (SERVER) then
 					return client:NotifyLocalized("canNotAfford")
 				end
 
+				if !entity:CanSellToPlayer(client, uniqueID) then
+					return false
+				end
+
 				local name = L(ix.item.list[uniqueID].name, client)
 
 				client:GetCharacter():TakeMoney(price, price == 0)


### PR DESCRIPTION
The essence of the exploit is that you can buy those things that have the “Buy Only” status.