### PR TITLE
Fix database connection

### DIFF
--- a/gamemode/core/hooks/sv_hooks.lua
+++ b/gamemode/core/hooks/sv_hooks.lua
@@ -768,14 +768,15 @@ end
 function GM:ShutDown()
 	ix.shuttingDown = true
 	ix.config.Save()
+	if ix.database_connected then
+		hook.Run("SaveData")
 
-	hook.Run("SaveData")
+		for _, v in ipairs(player.GetAll()) do
+			v:SaveData()
 
-	for _, v in ipairs(player.GetAll()) do
-		v:SaveData()
-
-		if (v:GetCharacter()) then
-			v:GetCharacter():Save()
+			if (v:GetCharacter()) then
+				v:GetCharacter():Save()
+			end
 		end
 	end
 end
@@ -945,7 +946,8 @@ function GM:DatabaseConnected()
 	ix.log.LoadTables()
 
 	MsgC(Color(0, 255, 0), "Database Type: " .. ix.db.config.adapter .. ".\n")
-
+	ix.database_connected = true
+	ix.database_start_connected = true
 	timer.Create("ixDatabaseThink", 0.5, 0, function()
 		mysql:Think()
 	end)

--- a/gamemode/core/hooks/sv_hooks.lua
+++ b/gamemode/core/hooks/sv_hooks.lua
@@ -437,7 +437,7 @@ ix.allowedHoldableClasses = {
 }
 
 function GM:CanPlayerHoldObject(client, entity)
-	if (entity and entity.GetClass and ix.allowedHoldableClasses[entity:GetClass()]) then
+	if (ix.allowedHoldableClasses[entity:GetClass()]) then
 		return true
 	end
 end

--- a/gamemode/core/hooks/sv_hooks.lua
+++ b/gamemode/core/hooks/sv_hooks.lua
@@ -437,7 +437,7 @@ ix.allowedHoldableClasses = {
 }
 
 function GM:CanPlayerHoldObject(client, entity)
-	if (ix.allowedHoldableClasses[entity:GetClass()]) then
+	if (entity and entity.GetClass and ix.allowedHoldableClasses[entity:GetClass()]) then
 		return true
 	end
 end

--- a/gamemode/core/libs/sv_database.lua
+++ b/gamemode/core/libs/sv_database.lua
@@ -159,8 +159,23 @@ end
 
 hook.Add("InitPostEntity", "ixDatabaseConnect", function()
 	-- Connect to the database using SQLite, mysqoo, or tmysql4.
+	ix.database_start_connected = false
 	ix.db.Connect()
+	timer.Create("START_FIX_DB_CONNECTED", 10, 0, function()
+		if ix.database_start_connected == false then
+			ix.db.Connect()
+		else
+			timer.Remove("START_FIX_DB_CONNECTED")
+		end
+	end)
 end)
+
+hook.Add("CheckPassword", "NoDatabaseConnectedStartServer", function()
+	if !ix.database_start_connected then
+		return false, "Database not connected"
+	end
+end)
+
 
 local resetCalled = 0
 

--- a/plugins/vendor/sh_plugin.lua
+++ b/plugins/vendor/sh_plugin.lua
@@ -403,6 +403,10 @@ if (SERVER) then
 					return client:NotifyLocalized("canNotAfford")
 				end
 
+				if !entity:CanSellToPlayer(client, uniqueID) then
+					return false
+				end
+
 				local name = L(ix.item.list[uniqueID].name, client)
 
 				client:GetCharacter():TakeMoney(price, price == 0)


### PR DESCRIPTION
If a server with the MySQL module starts and the offline database (or for some other reason) does not connect to it at startup and then appears online, then with this fix the server will try to connect every 10 seconds until the connection is restored. Basic protection has also been made against the fact that LoadData did not work and SaveData worked. There may be a situation that you have entities that are saved via SaveData, and since there was no LoadData, the file will become empty due to the absence of the necessary entities.