### PR TITLE
Fallback ix.log.Parse() Invalid Type

### DIFF
--- a/gamemode/core/libs/sh_log.lua
+++ b/gamemode/core/libs/sh_log.lua
@@ -63,8 +63,15 @@ if (SERVER) then
 		local info = ix.log.types[logType]
 
 		if (!info) then
-			ErrorNoHalt("attempted to add entry to non-existent log type \"" .. tostring(logType) .. "\"")
-			return
+			ErrorNoHalt("attempted to add entry to non-existent log type \"" .. tostring(logType) .. "\"\n")
+			local fallback = logType.." : "
+			if (client) then
+				fallback = fallback..client:Name().." - "
+			end
+			for k, v in ipairs({...}) do
+				fallback = fallback..tostring(v).." "
+			end
+			return fallback, FLAG_WARNING
 		end
 
 		local text = info and info.format


### PR DESCRIPTION
```lua
Error: gamemodes/helix/gamemode/core/libs/sh_log.lua:115: bad argument #1 to 'WriteString' (string expected, got nil)
  [C]:-1 - WriteString()
    gamemodes/helix/gamemode/core/libs/sh_log.lua:115 - Send()
      gamemodes/helix/gamemode/core/libs/sh_log.lua:105 - callback()
        addons/sam-153/lua/sam/modules/cami.lua:304 - onResult()
          addons/sam-153/lua/sam/modules/cami.lua:309 - callback()
            addons/sam-153/lua/sam/modules/support_cami.lua:122 - v()
              lua/includes/modules/hook.lua:96 - Call()
                addons/sam-153/lua/sam/modules/cami.lua:269 - PlayerHasAccess()
                  addons/sam-153/lua/sam/modules/cami.lua:308 - GetPlayersWithAccess()
                    gamemodes/helix/gamemode/core/libs/sh_log.lua:104 - Add()
                      gamemodes/helix/gamemode/core/libs/sh_command.lua:519 - Run()
                        gamemodes/helix/gamemode/core/libs/sh_command.lua:561 - Parse()
                          gamemodes/helix/gamemode/core/hooks/sv_hooks.lua:324 - Run()
                            gamemodes/helix/plugins/chatbox/sh_plugin.lua:154 - func()
                              lua/includes/extensions/net.lua:38 - ()
```
When using command without the loggin plugins. (Can also generate `Warning! A net message (ixLogStream) is already started! Discarding in favor of the new message! ...`)
Could also generate an attempt to concatenate nil error without cami.

This fix both of that.

Added a fallback so we dont get a huge stack trace due to the return nil not being asserted. The fallback also allow to actually log as a generic.