### PR TITLE
Player model error change fix

### DIFF
--- a/gamemode/core/hooks/sh_hooks.lua
+++ b/gamemode/core/hooks/sh_hooks.lua
@@ -320,6 +320,10 @@ function GM:PlayerSwitchWeapon(client, oldWeapon, weapon)
 end
 
 function GM:PlayerModelChanged(client, model)
+	if (!model) then
+		return
+	end
+	
 	client.ixAnimModelClass = ix.anim.GetModelClass(model)
 
 	UpdateAnimationTable(client)

--- a/gamemode/core/libs/sh_anims.lua
+++ b/gamemode/core/libs/sh_anims.lua
@@ -374,6 +374,10 @@ end
 -- @usage ix.anim.GetModelClass("models/police.mdl")
 -- > metrocop
 function ix.anim.GetModelClass(model)
+	if (!model) then
+		return
+	end
+	
 	model = string.lower(model)
 	local class = translations[model]
 


### PR DESCRIPTION
Sometimes if you spawn a bot, and for some reason the model bugs out, it starts to error due to no validation checks for the GetModelClass function and PlayerModelChanged hook.