### PR TITLE
Fixed config derma not working with array settings

### DIFF
--- a/gamemode/core/derma/cl_config.lua
+++ b/gamemode/core/derma/cl_config.lua
@@ -47,6 +47,7 @@ function PANEL:Populate()
 
 			local row = self:AddRow(type, categoryPhrase)
 			row:SetText(ix.util.ExpandCamelCase(k))
+			row:Populate(k, v.data)
 
 			-- type-specific properties
 			if (type == ix.type.number) then


### PR DESCRIPTION
Populate function required for array type setting rows was missing from the population function for ixConfigManager, which resulted in an empty options array for the ComboBox element.