### PR TITLE
Added Vendor Argument to CanPlayerUseVendor

### DIFF
--- a/docs/hooks/plugin.lua
+++ b/docs/hooks/plugin.lua
@@ -323,8 +323,12 @@ end
 function CanPlayerUseDoor(client, entity)
 end
 
---- @realm server
-function CanPlayerUseVendor(activator)
+--- Determines whether a player can use a vendor.
+-- @realm server
+-- @player activator The player attempting to use the vendor
+-- @entity vendor The vendor entity being used
+-- @treturn bool Returns false if the player can't use the vendor
+function CanPlayerUseVendor(activator, vendor)
 end
 
 --- @realm client

--- a/plugins/vendor/entities/entities/ix_vendor.lua
+++ b/plugins/vendor/entities/entities/ix_vendor.lua
@@ -171,7 +171,7 @@ if (SERVER) then
 	function ENT:Use(activator)
 		local character = activator:GetCharacter()
 
-		if (!self:CanAccess(activator) or hook.Run("CanPlayerUseVendor", activator) == false) then
+		if (!self:CanAccess(activator) or hook.Run("CanPlayerUseVendor", activator, self) == false) then
 			if (self.messages[VENDOR_NOTRADE]) then
 				activator:ChatPrint(self:GetDisplayName()..": "..self.messages[VENDOR_NOTRADE])
 			else


### PR DESCRIPTION
I feel like some players may want to add variables to vendors, which can prevent accessing the vendor. This will likely not be used a lot, but I feel like it would be worth having.