### PR TITLE
fixed a stack overflow in Character:KickClass()

### DIFF
--- a/gamemode/core/libs/sh_class.lua
+++ b/gamemode/core/libs/sh_class.lua
@@ -178,6 +178,8 @@ if (SERVER) then
 			end
 		end
 
+		if (!goClass) then return end
+
 		self:JoinClass(goClass)
 
 		hook.Run("PlayerJoinedClass", client, goClass)


### PR DESCRIPTION
This will prevent an overflow because `char:JoinClass()` expects a valid class. If the current faction doesn't have any class, `goClass` will be `nil`, leading to the call of `char:KickClass()` again. It's unclear if `char:KickClass()` should set the class to `nil` or to the default class in this case. Ideally, calling `char:KickClass()` should either set the character to the default class of the current faction or remove the old class entirely if no default class is found in that faction.
