### PR TITLE
Fixed previous character ban preventing later checks from happening

### DIFF
--- a/gamemode/core/hooks/sh_hooks.lua
+++ b/gamemode/core/hooks/sh_hooks.lua
@@ -419,18 +419,14 @@ function GM:CanPlayerUseCharacter(client, character)
 	local banned = character:GetData("banned")
 
 	if (banned) then
-		if (isnumber(banned)) then
-			if (banned < os.time()) then
-				goto charBanBypass
-			end
-
-			return false, "@charBannedTemp"
-		end
-
-		return false, "@charBanned"
+		if (!isnumber(banned)) then
+            return false, "@charBanned"
+        else
+            if (banned > os.time()) then
+                return false, "@charBannedTemp"
+            end
+        end
 	end
-
-	::charBanBypass::
 
 	local bHasWhitelist = client:HasWhitelist(character:GetFaction())
 

--- a/gamemode/core/hooks/sh_hooks.lua
+++ b/gamemode/core/hooks/sh_hooks.lua
@@ -421,7 +421,7 @@ function GM:CanPlayerUseCharacter(client, character)
 	if (banned) then
 		if (isnumber(banned)) then
 			if (banned < os.time()) then
-				return
+				goto charBanBypass
 			end
 
 			return false, "@charBannedTemp"
@@ -429,6 +429,8 @@ function GM:CanPlayerUseCharacter(client, character)
 
 		return false, "@charBanned"
 	end
+
+	::charBanBypass::
 
 	local bHasWhitelist = client:HasWhitelist(character:GetFaction())
 


### PR DESCRIPTION
In the CanPlayerUseCharacter hook, there is a check to make sure the character isnt banned. If the character received a temporary ban at some point and that ban runs out, the check in that function calls return, if the ban isnt valid anymore, preventing later checks from happening, which could for instance let a whitelist character load, as the whitelist check would not happen.