### PR TITLE
Swap sh_crossbowammo.txt model

### DIFF
--- a/gamemode/items/ammo/sh_crossbowammo.txt
+++ b/gamemode/items/ammo/sh_crossbowammo.txt
@@ -1,5 +1,5 @@
 ITEM.name = "Crossbow Bolts"
-ITEM.model = "models/Items/BoxBuckshot.mdl"
+ITEM.model = "models/Items/CrossbowRounds.mdl"
 ITEM.ammo = "XBowRounds" -- type of the ammo
 ITEM.ammoAmount = 5 -- amount of the ammo
 ITEM.description = "A Bundle of %s Crossbow Bolts"


### PR DESCRIPTION
For some reason, the default model is set to BoxBuckshot.mdl when CrossbowRounds.mdl exists. This change will save a whopping five seconds of time at most.