### PR TITLE
Adds ix.util.GetUserByCharacterID

### DIFF
--- a/gamemode/core/sh_util.lua
+++ b/gamemode/core/sh_util.lua
@@ -388,7 +388,25 @@ do
 		return iterator, player.GetAll()
 	end
 end
-
+--- Retrieves the client associated with a character by their character ID.
+-- @realm shared
+-- @tparam number ID The ID of the character to find the associated client
+-- @treturn player|nil The client associated with the character, or `nil` if no client is found
+-- @usage
+-- local client = ix.util.GetUserByCharacterID(123)
+-- if IsValid(client) then
+--     print(client:Nick() .. " is the player associated with the character ID.")
+-- else
+--     print("No client found for that character ID.")
+-- end
+function ix.util.GetUserByCharacterID(ID)
+    ID = tonumber(ID)
+    for client, character in ix.util.GetCharacters() do
+        if not character then continue end
+        if character:GetID() == ID then return client end
+    end
+    return nil
+end
 if (CLIENT) then
 	local blur = ix.util.GetMaterial("pp/blurscreen")
 	local surface = surface


### PR DESCRIPTION
Just a utility function that retrieves a user by a given SteamID, if they are online. This isn't used in many scenarios, but it can be fairly useful in some.