### PR TITLE
Fix chatbox plugin with OnPauseMenuShow

### DIFF
--- a/plugins/chatbox/derma/cl_chatbox.lua
+++ b/plugins/chatbox/derma/cl_chatbox.lua
@@ -914,6 +914,8 @@ function PANEL:DraggingInBounds()
 	return mouseY > screenY and mouseY < screenY + self.tabs.buttons:GetTall()
 end
 
+local ixChatboxActive = false
+
 function PANEL:SetActive(bActive)
 	if (bActive) then
 		self:SetAlpha(255)
@@ -954,6 +956,7 @@ function PANEL:SetActive(bActive)
 	end
 
 	self.bActive = tobool(bActive)
+	ixChatboxActive = tobool(bActive)
 end
 
 function PANEL:SetupTabs(tabs)
@@ -1073,15 +1076,23 @@ function PANEL:OnMouseReleased()
 	end
 end
 
+local ixDisableChatbox = false
+
+hook.Add("OnPauseMenuShow", "ixCloseChatboxOnPause", function()
+    if ixChatboxActive then
+		ixDisableChatbox = true
+		timer.Simple(0.1, function() ixDisableChatbox = false end)
+		return false
+	end
+end)
+
 function PANEL:Think()
 	if (!self.bActive) then
 		return
 	end
 
-	if (gui.IsGameUIVisible()) then
+	if gui.IsGameUIVisible() or ixDisableChatbox then
 		self:SetActive(false)
-		gui.HideGameUI()
-
 		return
 	end
 


### PR DESCRIPTION
Hello, with the last update in gmod the function gui.HideGameUI() has been totally unabled from gmod and throw an error when you call this function. The error says "game.HideGameUI() is no longer functional. Use GM:OnPauseMenuShow hook.".
In the plugin of chatbox when you press escape to close the chat the code throw that error and the chat keeps on the top of the gmod pause menu. So I create 2 vars to detect when the chat is enabled and if it need to be closed and the hook OnPauseMenuShow. The hook just change the variable ixDisableChatbox to true and 0.1 seconds later changes it to false, so the Think automatically do a self:SetActive(false). Why not use self:SetActive(false) (or PANEL:SetActive(false))? Because if you call this in the hook or in another custom function it throw an error. This method works fine and doesn't show the annoying notify of OnPauseMenuBlockedTooManyTimes (unless you spam the chat key and closing it).