### PR TITLE
stamina: Move speed reduction to a SetupMove

### DIFF
--- a/plugins/stamina/sh_plugin.lua
+++ b/plugins/stamina/sh_plugin.lua
@@ -78,11 +78,11 @@ local function CalcStaminaChange(client)
 	end
 end
 
-hook.Add("SetupMove", "StaminaSpeedReduction", function(client, mv, cmd)
+function PLUGIN:SetupMove(client, mv, cmd)
 	if client:GetNetVar("brth", false) then
 		mv:SetMaxClientSpeed(client:GetWalkSpeed())
 	end
-end)
+end
 
 if (SERVER) then
 	function PLUGIN:PostPlayerLoadout(client)

--- a/plugins/stamina/sh_plugin.lua
+++ b/plugins/stamina/sh_plugin.lua
@@ -79,7 +79,7 @@ local function CalcStaminaChange(client)
 end
 
 function PLUGIN:SetupMove(client, mv, cmd)
-	if client:GetNetVar("brth", false) then
+	if (client:GetNetVar("brth", false)) then
 		mv:SetMaxClientSpeed(client:GetWalkSpeed())
 	end
 end

--- a/plugins/stamina/sh_plugin.lua
+++ b/plugins/stamina/sh_plugin.lua
@@ -63,7 +63,6 @@ local function CalcStaminaChange(client)
 			client:SetLocalVar("stm", value)
 
 			if (value == 0 and !client:GetNetVar("brth", false)) then
-				client:SetRunSpeed(walkSpeed)
 				client:SetNetVar("brth", true)
 
 				character:UpdateAttrib("end", 0.1)
@@ -71,7 +70,6 @@ local function CalcStaminaChange(client)
 
 				hook.Run("PlayerStaminaLost", client)
 			elseif (value >= 50 and client:GetNetVar("brth", false)) then
-				client:SetRunSpeed(runSpeed)
 				client:SetNetVar("brth", nil)
 
 				hook.Run("PlayerStaminaGained", client)
@@ -80,6 +78,11 @@ local function CalcStaminaChange(client)
 	end
 end
 
+hook.Add("SetupMove", "StaminaSpeedReduction", function(client, mv, cmd)
+	if client:GetNetVar("brth", false) then
+		mv:SetMaxClientSpeed(client:GetWalkSpeed())
+	end
+end)
 
 if (SERVER) then
 	function PLUGIN:PostPlayerLoadout(client)


### PR DESCRIPTION
We should not be forcing the speed of anything in a temporary manner, especially reverting back to config values when these may not be the values that were being used.

Credits to @WardenPotato for explaining this to me and offering a solution when I ran into issues with this exact behavior.