### PR TITLE
Fix Chatbox on change tab name

### DIFF
--- a/plugins/chatbox/derma/cl_chatbox.lua
+++ b/plugins/chatbox/derma/cl_chatbox.lua
@@ -1260,8 +1260,8 @@ function PANEL:OnTabUpdated(id, filter, newID)
 		return
 	end
 
-	tab:SetFilter(filter)
-	self.tabs:RenameTab(id, newID)
+	self.tabs:AddTab(newID, filter)
+	self.tabs:RemoveTab(id)
 
 	PLUGIN:SaveTabs()
 end

--- a/plugins/chatbox/derma/cl_chatboxcustomize.lua
+++ b/plugins/chatbox/derma/cl_chatboxcustomize.lua
@@ -89,7 +89,7 @@ end
 function PANEL:CreateClicked()
 	local name = self.tab and self.tab or self.name:GetValue()
 
-	if (self.tab != self.name:GetValue() and PLUGIN:TabExists(name)) then
+	if (self.tab != self.name:GetValue() and PLUGIN:TabExists(self.name:GetValue())) then
 		ix.util.Notify(L("chatTabExists"))
 		return
 	end


### PR DESCRIPTION
This fixes the plugin Chatbox because if you try to update the name, the plugin returns you the notify 'chatTabExists'. If you only fix the cl_chatboxcustomize.lua, you can't update the name more than 1 time before it bugs. My best solution is replace the RenameTab function for AddTab and RemoveTab in cl_chatbox.lua.