### PR TITLE
Chatbox Tab renaming fixes.

### DIFF
--- a/plugins/chatbox/derma/cl_chatbox.lua
+++ b/plugins/chatbox/derma/cl_chatbox.lua
@@ -170,7 +170,7 @@ function PANEL:AddTab(id, filter)
 	panel:SetFilter(filter or {})
 
 	button.DoRightClick = function(this)
-		ix.gui.chat:OnTabRightClick(this, panel, id)
+		ix.gui.chat:OnTabRightClick(this, panel, panel:GetID())
 	end
 
 	self.tabs[id] = panel
@@ -209,8 +209,14 @@ function PANEL:RenameTab(id, newID)
 	tab:GetButton():SetText(newID)
 	tab:GetButton():SizeToContents()
 
+	tab:SetID(newID)
+
 	self.tabs[id] = nil
 	self.tabs[newID] = tab
+
+	if (id == self:GetActiveTabID()) then
+		self:SetActiveTab(newID)
+	end
 end
 
 function PANEL:SetActiveTab(id)

--- a/plugins/chatbox/derma/cl_chatboxcustomize.lua
+++ b/plugins/chatbox/derma/cl_chatboxcustomize.lua
@@ -89,7 +89,7 @@ end
 function PANEL:CreateClicked()
 	local name = self.tab and self.tab or self.name:GetValue()
 
-	if (self.tab != self.name:GetValue() and PLUGIN:TabExists(name)) then
+	if (self.tab != self.name:GetValue() and PLUGIN:TabExists(self.name:GetValue())) then
 		ix.util.Notify(L("chatTabExists"))
 		return
 	end


### PR DESCRIPTION
This adds some missing logic for handling chatbox tab renaming. Helix would produce an unexpected 'This tab already exists' error when renaming a chat tab. When that issue is fixed, the tab is still not properly renamed due to mismatched IDs, and the active tab variable is not updated to point to the new ID, causing an error.