### PR TITLE
Allow global table vars to always be networked.

### DIFF
--- a/gamemode/core/libs/sv_networking.lua
+++ b/gamemode/core/libs/sv_networking.lua
@@ -38,7 +38,7 @@ end
 
 function SetNetVar(key, value, receiver) -- luacheck: globals SetNetVar
 	if (CheckBadType(key, value)) then return end
-	if (GetNetVar(key) == value) then return end
+	if (GetNetVar(key) == value and !istable(value)) then return end
 
 	ix.net.globals[key] = value
 


### PR DESCRIPTION
This fixes an issue with global variables when a table is networked.

The problem is that if a table that is a global variable is changed in any way, because tables in Lua are references, the table will also change in `ix.net.globals`, meaning that the check on line 41 would essentially be comparing the table with itself, which would always return true, and thus never actually be networked.

This adds an exception for tables to make them always pass that check, in order to be properly networked.