### PR TITLE
ixAttributeBar animate speed param

### DIFF
--- a/gamemode/core/derma/cl_attribute.lua
+++ b/gamemode/core/derma/cl_attribute.lua
@@ -51,6 +51,7 @@ function PANEL:Init()
 	self.value = 0
 	self.deltaValue = self.value
 	self.max = 10
+	self.animateSpeed = 15
 
 	self.bar = self:Add("DPanel")
 	self.bar:Dock(FILL)
@@ -134,7 +135,7 @@ function PANEL:Think()
 		end
 	end
 
-	self.deltaValue = math.Approach(self.deltaValue, self.value, FrameTime() * 15)
+	self.deltaValue = math.Approach(self.deltaValue, self.value, FrameTime() * self.animateSpeed)
 end
 
 function PANEL:DoChange()


### PR DESCRIPTION
change the bar fill speed to a variable instead of magic number
sometimes it's too slow or fast for our needs, just set pnl.animateSpeed to something higher or lower