### PR TITLE
Fixed plugins inside plugins (Repost)

### DIFF
--- a/gamemode/core/libs/sh_plugin.lua
+++ b/gamemode/core/libs/sh_plugin.lua
@@ -83,7 +83,7 @@ function ix.plugin.Load(uniqueID, path, isSingleFile, variable)
 		end
 
 		ix.plugin.list[uniqueID] = PLUGIN
-		_G[variable] = nil
+		_G[variable] = oldPlugin
 	end
 
 	if (PLUGIN.OnLoaded) then


### PR DESCRIPTION
Accidentally closed this PR.

The change would set the global variable "PLUGIN" to the local variable oldPlugin after a plugin is loaded to allow plugins inside plugins. This change does not result in the PLUGIN global variable staying even after all plugins have been defined. See below for a detailed step by step analysis as to why.

Firstly a new plugin is loaded using ipL. For this explanation, let's say that this is the first plugin that is loaded overall and that it has one or multiple plugins in its plugins folder. So this is what the directory looks like plugin/plugins/nested_plugin.
At this line: https://github.com/NebulousCloud/helix/blob/8cab35ebacdd244981226a3f3c5d8480fd430d12/gamemode/core/libs/sh_plugin.lua#L17
the local variable "oldPlugin" is set to the gv (global variable) "PLUGIN", however because this is the first plugin to be loaded, the gv "PLUGIN" is nil, as such oldPlugin is nil. This is important for later.
Next, the function continues as normal until it reaches this line:
https://github.com/NebulousCloud/helix/blob/8cab35ebacdd244981226a3f3c5d8480fd430d12/gamemode/core/libs/sh_plugin.lua#L48
Right here, it loads the nested plugin (nested_plugin), which calls ipL again.
This time when we reach line 17: https://github.com/NebulousCloud/helix/blob/8cab35ebacdd244981226a3f3c5d8480fd430d12/gamemode/core/libs/sh_plugin.lua#L17
the gv "PLUGIN" is not nil, it is the plugin table from the original plugin, as such oldPlugin will not be nil.
We continue towards the end of ipL, still loading the nested plugin:
https://github.com/NebulousCloud/helix/blob/8cab35ebacdd244981226a3f3c5d8480fd430d12/gamemode/core/libs/sh_plugin.lua#L86
Right here the gv "PLUGIN" is set to oldPlugin. Why? Because the actual gv "PLUGIN" variable was replaced by the nested plugin's table. In order to allow the original plugin to continue loading, it has to be set to oldPlugin, which for the nested plugin is equal to the original plugin's table.

Now we return to loading the original plugin. We continue to the same again:
https://github.com/NebulousCloud/helix/blob/8cab35ebacdd244981226a3f3c5d8480fd430d12/gamemode/core/libs/sh_plugin.lua#L86
This time though because oldPlugin is nil (because gv "PLUGIN" was undefined), the gv "PLUGIN" is also set to nil, thus once the plugin is loaded, we won't have left behind a gv.

TLDR:
Plugin 1 loads, calls ipL to load a nested plugin, plugin 2. It sets a local variable "oldPlugin" to plugin 1's table. It finishes loading setting PLUGIN to plugin 2's local "oldPlugin" variable (so to plugin 1's table). Plugin 1 then sets PLUGIN to it's local variable "oldPlugin" which is nil, so PLUGIN is nil after loading.