### PR TITLE
fixed a possible error in `RequestString`.

### DIFF
--- a/gamemode/core/meta/sh_player.lua
+++ b/gamemode/core/meta/sh_player.lua
@@ -337,7 +337,7 @@ if (SERVER) then
 			net.WriteUInt(time, 32)
 			net.WriteString(title)
 			net.WriteString(subTitle)
-			net.WriteString(default)
+			net.WriteString(default or "")
 		net.Send(self)
 	end
 


### PR DESCRIPTION
The comment above states that the `default` argument is optional, but trying not to pass it into the function call throws an error because `net.WriteString` cannot pass `nil`.