### PR TITLE
Configurable Interaction Range for ENT:OnOptionSelected()

### DIFF
--- a/gamemode/config/sh_config.lua
+++ b/gamemode/config/sh_config.lua
@@ -182,6 +182,11 @@ ix.config.Add("itemPickupTime", 0.5, "How long it takes to pick up and put an it
 	data = {min = 0, max = 5, decimals = 1},
 	category = "interaction"
 })
+ix.config.Add("interactionRange", 96, "Maximum range to interact with an entity.", nil, {
+	data = {min = 50, max = 250, decimals = 0},
+	category = "interaction"
+})
+
 ix.config.Add("year", 2015, "The current in-game year.", function(oldValue, newValue)
 	if (SERVER and !ix.date.bSaving) then
 		ix.date.ResolveOffset()

--- a/gamemode/core/libs/sh_menu.lua
+++ b/gamemode/core/libs/sh_menu.lua
@@ -74,7 +74,7 @@ else
 
 		if (!IsValid(entity) or !isstring(option) or
 			hook.Run("CanPlayerInteractEntity", client, entity, option, data) == false or
-			entity:GetPos():Distance(client:GetPos()) > 96) then
+			entity:GetPos():Distance(client:GetPos()) > ix.config.Get("interactionRange", 96) then
 			return
 		end
 

--- a/gamemode/core/libs/sh_menu.lua
+++ b/gamemode/core/libs/sh_menu.lua
@@ -74,7 +74,7 @@ else
 
 		if (!IsValid(entity) or !isstring(option) or
 			hook.Run("CanPlayerInteractEntity", client, entity, option, data) == false or
-			entity:GetPos():Distance(client:GetPos()) > ix.config.Get("interactionRange", 96) then
+			entity:GetPos():Distance(client:GetPos()) > ix.config.Get("interactionRange", 96)) then
 			return
 		end
 


### PR DESCRIPTION
On entity with big model (like `models/props_wasteland/laundry_washer001a.mdl`), the default interaction range of 96 is too small. Also servers may want to allow extra  (or smaller) reach.

- Added a new config in Interaction Category, interactioRange, ranging from 50 to 250, and used it instead of the default 96 to filter  `ENT:OnOptionSelected()` client request.