### PR TITLE
Fixed issue with attribute bar not being max value

### DIFF
--- a/gamemode/core/libs/sh_character.lua
+++ b/gamemode/core/libs/sh_character.lua
@@ -614,7 +614,7 @@ do
 
 			-- total spendable attribute points
 			local totalBar = attributes:Add("ixAttributeBar")
-			totalBar:SetMax(v.maxValue or maximum)
+			totalBar:SetMax(maximum)
 			totalBar:SetValue(maximum)
 			totalBar:Dock(TOP)
 			totalBar:DockMargin(2, 2, 2, 2)
@@ -628,7 +628,7 @@ do
 				payload.attributes[k] = 0
 
 				local bar = attributes:Add("ixAttributeBar")
-				bar:SetMax(maximum)
+				bar:SetMax(v.maxValue or maximum)
 				bar:Dock(TOP)
 				bar:DockMargin(2, 2, 2, 2)
 				bar:SetText(L(v.name))

--- a/gamemode/core/libs/sh_character.lua
+++ b/gamemode/core/libs/sh_character.lua
@@ -614,7 +614,7 @@ do
 
 			-- total spendable attribute points
 			local totalBar = attributes:Add("ixAttributeBar")
-			totalBar:SetMax(maximum)
+			totalBar:SetMax(v.maxValue or maximum)
 			totalBar:SetValue(maximum)
 			totalBar:Dock(TOP)
 			totalBar:DockMargin(2, 2, 2, 2)


### PR DESCRIPTION
The max value for the attribute bar should match the maxValue variable that is set when defining an attribute instead of the overall attribute maximum.