### PR TITLE
Set max attribute to what local config value is set to

### DIFF
--- a/gamemode/core/libs/sh_character.lua
+++ b/gamemode/core/libs/sh_character.lua
@@ -598,7 +598,7 @@ do
 		category = "attributes",
 		isLocal = true,
 		OnDisplay = function(self, container, payload)
-			local maximum = hook.Run("GetDefaultAttributePoints", LocalPlayer(), payload) or 10
+			local maximum = hook.Run("GetDefaultAttributePoints", LocalPlayer(), payload) or ix.config.Get("maxAttributes", 10)
 
 			if (maximum < 1) then
 				return
@@ -662,7 +662,7 @@ do
 						count = count + v
 					end
 
-					if (count > (hook.Run("GetDefaultAttributePoints", client, count) or 10)) then
+					if (count > (hook.Run("GetDefaultAttributePoints", client, count) or ix.config.Get("maxAttributes", 10))) then
 						return false, "unknownError"
 					end
 				else


### PR DESCRIPTION
This change allows the max attribute to respect what the server's maxAttribute config is set to