### PR TITLE
Remove footlocker registration from container definitions

### DIFF
--- a/plugins/containers/sh_definitions.lua
+++ b/plugins/containers/sh_definitions.lua
@@ -104,13 +104,6 @@ ix.container.Register("models/items/ammocrate_smg1.mdl", {
 	end
 })
 
-ix.container.Register("models/props_forest/footlocker01_closed.mdl", {
-	name = "Footlocker",
-	description = "A small chest to store belongings in.",
-	width = 5,
-	height = 3
-})
-
 ix.container.Register("models/Items/item_item_crate.mdl", {
 	name = "Item Crate",
 	description = "A crate to store some belongings in.",


### PR DESCRIPTION
The model "models/props_forest/footlocker01_closed.mdl" is currently not a vanilla Garry's Mod model, so it doesn't make sense to have it registered in Helix base. I believe Half-Life 2: Episode 2 content is required to properly view this model.