### PR TITLE
Target selectors for ix.command.find player

### DIFF
--- a/gamemode/core/libs/sh_command.lua
+++ b/gamemode/core/libs/sh_command.lua
@@ -438,12 +438,15 @@ if (SERVER) then
 	util.AddNetworkString("ixCommand")
 
 	--- Attempts to find a player by an identifier. If unsuccessful, a notice will be displayed to the specified player. The
-	-- search criteria is derived from `ix.util.FindPlayer`.
+	-- search criteria is derived from `ix.util.FindPlayer`. This command also allows for the usage of two target selectors in place of a character name.
+	-- `^` will target the command caller, in this case `client`. Using `@` will instead target the player, that the command
+	-- caller is looking at. This also works for looking at ragdolled players.
 	-- @realm server
 	-- @player client Player to give a notification to if the player could not be found
 	-- @string name Search query
 	-- @treturn[1] player Player that matches the given search query
-	-- @treturn[2] nil If a player could not be found
+	-- @treturn[2] string Error message if `client` looks at an invalid player and attempts to use the `@` target selector
+	-- @treturn[3] nil If a player could not be found
 	-- @see ix.util.FindPlayer
 	function ix.command.FindPlayer(client, name)
 		if (isstring(name)) then

--- a/gamemode/core/libs/sh_command.lua
+++ b/gamemode/core/libs/sh_command.lua
@@ -109,7 +109,7 @@ local function ArgumentCheckStub(command, client, given)
 			result[#result + 1] = value
 		elseif (argType == ix.type.player or argType == ix.type.character) then
 			local bPlayer = argType == ix.type.player
-			local value = ix.util.FindPlayer(argument or "") -- argument could be nil due to optional type
+			local value = ix.command.FindPlayer(client, argument or "") -- argument could be nil due to optional type
 
 			-- FindPlayer emits feedback for us
 			if (!value and !bOptional) then
@@ -443,12 +443,25 @@ if (SERVER) then
 	-- @treturn[2] nil If a player could not be found
 	-- @see ix.util.FindPlayer
 	function ix.command.FindPlayer(client, name)
-		local target = isstring(name) and ix.util.FindPlayer(name) or NULL
+		if (isstring(name)) then
+			if (name == "^") then
+				return client
+			elseif (name == "@") then
+				local entity = client:GetEyeTrace().Entity
+				if (IsValid(entity)) then
+					if (entity:IsPlayer()) then
+						return entity
+					elseif (IsValid(entity.ixPlayer) and entity.ixPlayer:IsPlayer()) then
+						return entity.ixPlayer
+					end
+				end
+				return
+			end
 
-		if (IsValid(target)) then
-			return target
-		else
-			client:NotifyLocalized("plyNoExist")
+			local target = ix.util.FindPlayer(name)
+			if (IsValid(target)) then
+				return target
+			end
 		end
 	end
 

--- a/gamemode/core/libs/sh_command.lua
+++ b/gamemode/core/libs/sh_command.lua
@@ -112,7 +112,10 @@ local function ArgumentCheckStub(command, client, given)
 			local value = ix.command.FindPlayer(client, argument or "") -- argument could be nil due to optional type
 
 			-- FindPlayer emits feedback for us
-			if (!value and !bOptional) then
+			if (!IsValid(value) and !bOptional) then
+				if isstring(value) then
+					return L(value, client)
+				end
 				return L(bPlayer and "plyNoExist" or "charNoExist", client)
 			end
 
@@ -451,11 +454,11 @@ if (SERVER) then
 				if (IsValid(entity)) then
 					if (entity:IsPlayer()) then
 						return entity
-					elseif (IsValid(entity.ixPlayer) and entity.ixPlayer:IsPlayer()) then
+					elseif (IsValid(entity.ixPlayer)) then
 						return entity.ixPlayer
 					end
 				end
-				return
+				return "plyNotValid"
 			end
 
 			local target = ix.util.FindPlayer(name)

--- a/gamemode/core/sh_commands.lua
+++ b/gamemode/core/sh_commands.lua
@@ -587,7 +587,7 @@ ix.command.Add("PlyUnwhitelist", {
 		end
 
 		if (faction) then
-			local targetPlayer = ix.util.FindPlayer(target)
+			local targetPlayer = ix.command.FindPlayer(client, target)
 
 			if (IsValid(targetPlayer) and targetPlayer:SetWhitelisted(faction.index, false)) then
 				for _, v in player.Iterator() do


### PR DESCRIPTION
This PR implements two target selectors for chat commands: "^" targets the command caller, while "@" targets whoever the command caller is looking at, this also works with ragdolled players (as well as many others as it relies on the "ixPlayer" member variable that is used in certain places, like the scanner in the default HL2RP schema)

The local function "ArgumentCheckStub" in core/sh_commands.lua now uses ix.command.FindPlayer (which this PR changes), instead of ix.util.FindPlayer (which has not been changed).
Documentation for the ix.command.FindPlayer function was updated accordingly.
The functionality and basic code is inspired by NutScript's implementation. 