### PR TITLE
Fix inventory Iter returning non-item true values for not fully-instanced items

### DIFF
--- a/gamemode/core/meta/sh_inventory.lua
+++ b/gamemode/core/meta/sh_inventory.lua
@@ -572,7 +572,7 @@ function META:Iter()
 
 			item = self.slots[x] and self.slots[x][y]
 			x = x + 1
-		until item
+		until item and not isbool(item) -- skip reserved slots in which items have yet to be fully instantiated
 
 		if (item) then
 			return item, x, y


### PR DESCRIPTION
In `meta/sh_inventory.lua` to be added items have their slots reserved with a `true` value:
https://github.com/NebulousCloud/helix/blob/e5bc1e0be29848feb9b890f5affce59fd72071fd/gamemode/core/meta/sh_inventory.lua#L891

After this reservation an item instance will be created by `ix.item.Instance`, which may take some time, since it is in a query callback:
https://github.com/NebulousCloud/helix/blob/e5bc1e0be29848feb9b890f5affce59fd72071fd/gamemode/core/libs/sh_item.lua#L78-L96

Only once the query callback calls back with the fully instanced item, is the reserved `true` value replaced with the item.
https://github.com/NebulousCloud/helix/blob/e5bc1e0be29848feb9b890f5affce59fd72071fd/gamemode/core/meta/sh_inventory.lua#L907-L916

This commit excludes these mentioned `true` values when using `Iter`, since it would cause a `attempt to index local 'k' (a boolean value)` in multiple places in the framework because k is expected to be an item object, e.g:
https://github.com/NebulousCloud/helix/blob/e5bc1e0be29848feb9b890f5affce59fd72071fd/gamemode/core/meta/sh_inventory.lua#L958-L959
https://github.com/NebulousCloud/helix/blob/e5bc1e0be29848feb9b890f5affce59fd72071fd/plugins/pac.lua#L124-L125