### PR TITLE
Use SteamID64() instead of UniqueID()

### DIFF
--- a/gamemode/core/meta/sh_player.lua
+++ b/gamemode/core/meta/sh_player.lua
@@ -130,7 +130,7 @@ end
 -- end)
 -- -- prints "hello!" after looking at the entity for 4 seconds
 function meta:DoStaredAction(entity, callback, time, onCancel, distance)
-	local uniqueID = "ixStare"..self:UniqueID()
+	local uniqueID = "ixStare"..self:SteamID64()
 	local data = {}
 	data.filter = self
 
@@ -285,7 +285,7 @@ if (SERVER) then
 		finishTime = finishTime or (startTime + time)
 
 		if (text == false) then
-			timer.Remove("ixAct"..self:UniqueID())
+			timer.Remove("ixAct"..self:SteamID64())
 
 			net.Start("ixActionBarReset")
 			net.Send(self)
@@ -307,7 +307,7 @@ if (SERVER) then
 		-- If we have provided a callback, run it delayed.
 		if (callback) then
 			-- Create a timer that runs once with a delay.
-			timer.Create("ixAct"..self:UniqueID(), time, 1, function()
+			timer.Create("ixAct"..self:SteamID64(), time, 1, function()
 				-- Call the callback if the player is still valid.
 				if (IsValid(self)) then
 					callback(self)


### PR DESCRIPTION
Replace UniqueID() in sh_player.lua meta by SteamID64()
UniqueID is deprecated function. As it says on the [wiki](https://wiki.facepunch.com/gmod/Player:UniqueID): **This function has collisions, where more than one player can have the same UniqueID.**