### PR TITLE
Fix pacAdjust data not being removed correctly

### DIFF
--- a/plugins/pac.lua
+++ b/plugins/pac.lua
@@ -189,9 +189,15 @@ else
 	end
 
 	local function RemovePart(client, uniqueID)
+		local itemTable = ix.item.list[uniqueID]
 		local pacData = ix.pac.list[uniqueID]
 
 		if (pacData) then
+			if (itemTable and itemTable.pacAdjust) then
+				pacData = table.Copy(pacData)
+				pacData = itemTable:pacAdjust(pacData, client)
+			end
+
 			if (isfunction(client.RemovePACPart)) then
 				client:RemovePACPart(pacData)
 			else


### PR DESCRIPTION
In cases where pacAdjust returned results significantly different from the original pacData, RemovePart() would not call RemovePACPart() on the correct table and the part would become permanently stuck to the player.

This ensures that the pacData table passed to RemovePACPart matches the one initially attached by PAC, if needed.
