### PR TITLE
Enable InventoryItemRemoved call for ITEM:Remove()

### DIFF
--- a/gamemode/core/meta/sh_item.lua
+++ b/gamemode/core/meta/sh_item.lua
@@ -486,6 +486,10 @@ function ITEM:Remove(bNoReplication, bNoDelete)
 		if (!bNoDelete) then
 			local item = ix.item.instances[self.id]
 
+			if (inv and inv.owner) then
+				hook.Run("InventoryItemRemoved", inv, item)
+			end
+
 			if (item and item.OnRemoved) then
 				item:OnRemoved()
 			end


### PR DESCRIPTION
InventoryItemRemoved is a hook called when an item is removed via the INVENTORY:Remove() meta function on the server. Weirdly, the hook is NOT called when ITEM:Remove() is called on the server, despite the same "ixInventoryRemove" net message going out in both cases when the inventory exists.

This brings parity to both meta functions - when an item instance is removed directly from an inventory or self deleted when inside of a client's inventory, the hook will be called as is seemingly intended. This will only happen if the item is not being transferred, is inside of a client's inventory, and should be deleted.