### PR TITLE
Fix error with DHScrollBar in Derma skin and add support for it

### DIFF
--- a/gamemode/core/cl_skin.lua
+++ b/gamemode/core/cl_skin.lua
@@ -332,21 +332,43 @@ end
 function SKIN:PaintVScrollBar(panel, width, height)
 end
 
+function SKIN:PaintHScrollBar(panel, width, height)
+end
+
 function SKIN:PaintScrollBarGrip(panel, width, height)
 	local parent = panel:GetParent()
-	local upButtonHeight = parent.btnUp:GetTall()
-	local downButtonHeight = parent.btnDown:GetTall()
 
-	DisableClipping(true)
-		surface.SetDrawColor(30, 30, 30, 200)
-		surface.DrawRect(4, -upButtonHeight, width - 8, height + upButtonHeight + downButtonHeight)
-	DisableClipping(false)
+	if (IsValid(parent.btnUp)) then
+		-- Vertical scrollbar
+		local upButtonHeight = parent.btnUp:GetTall()
+		local downButtonHeight = parent.btnDown:GetTall()
+
+		DisableClipping(true)
+			surface.SetDrawColor(30, 30, 30, 200)
+			surface.DrawRect(4, -upButtonHeight, width - 8, height + upButtonHeight + downButtonHeight)
+		DisableClipping(false)
+	else
+		-- Horizontal scrollbar
+		local leftButtonWidth = parent.btnLeft:GetWide()
+		local rightButtonWidth = parent.btnRight:GetWide()
+
+		DisableClipping(true)
+			surface.SetDrawColor(30, 30, 30, 200)
+			surface.DrawRect(-leftButtonWidth, 4, width + leftButtonWidth + rightButtonWidth, height - 8)
+		DisableClipping(false)
+	end
 end
 
 function SKIN:PaintButtonUp(panel, width, height)
 end
 
 function SKIN:PaintButtonDown(panel, width, height)
+end
+
+function SKIN:PaintButtonLeft(panel, width, height)
+end
+
+function SKIN:PaintButtonRight(panel, width, height)
 end
 
 function SKIN:PaintComboBox(panel, width, height)


### PR DESCRIPTION
Fixed the Helix derma skin causing an error when using `DHScrollBar`.

Both `DVScrollBar` (Vertical) and `DHScrollBar` (Horizontal) call the `PaintScrollBarGrip` skin hook (through their **child** `DScrollBarGrip`). However currently in Helix the `PaintScrollBarGrip` skin hook expects `btnUp` and `btnDown` to exist on the **parent** (See changed files). This fails because `DHScrollBar` has `btnLeft` and `btnRight`, meaning without this PR its not possible to use `DHScrollBar` on a panel using the Helix skin. 

Besides this fix I added a few empty paint hooks to style the horizontal bar the same way as vertical bars are in Helix:
<img width="845" height="550" alt="styled horizontal bar" src="https://github.com/user-attachments/assets/83343780-d6cb-4738-b433-305fb1fe74aa" />

This shouldn't break anything and looking at the gmod source code [it doesn't seem `DScrollBarGrip` is used anywhere else](https://github.com/search?q=repo%3AFacepunch%2Fgarrysmod%20DScrollBarGrip&type=code) so this PR should be good.