### PR TITLE
Make container for main menu buttons scrollpanel

### DIFF
--- a/gamemode/core/derma/cl_menu.lua
+++ b/gamemode/core/derma/cl_menu.lua
@@ -64,7 +64,7 @@ function PANEL:Init()
 	self.guard:SetSize(self:GetPadding(), self:GetTall())
 
 	-- tabs
-	self.tabs = self.buttons:Add("Panel")
+	self.tabs = self.buttons:Add("DScrollPanel")
 	self.tabs.buttons = {}
 	self.tabs:Dock(FILL)
 	self:PopulateTabs()


### PR DESCRIPTION
_First of all: Thanks for the quick merges of my PR's recently 👍 and excuse these tiny PR's over the past few days. Let me know if you'd like a break from them and I'll refrain from making more PR's for a while_

This PR fixes not some main menu options being inaccessible when screen height is too 'small' for the number of buttons to display.

```lua
hook.Add("CreateMenuButtons", "test", function(tabs)
	tabs["test1"] = function(container)
		container:Add("MyTestPanel")
	end
	tabs["test2"] = function(container)
		container:Add("MyTestPanel")
	end
	tabs["test3"] = function(container)
		container:Add("MyTestPanel")
	end
	tabs["test4"] = function(container)
		container:Add("MyTestPanel")
	end
	tabs["test5"] = function(container)
		container:Add("MyTestPanel")
	end
	tabs["test6"] = function(container)
		container:Add("MyTestPanel")
	end
	tabs["test7"] = function(container)
		container:Add("MyTestPanel") -- overflows outside the panel on my resolution of 1600x900
	end
end)
```

**Before** this PR:
<img width="1555" height="884" alt="before" src="https://github.com/user-attachments/assets/334c9ac6-c4fe-459b-b28c-4fd27a006845" />

**After**:
<img width="1209" height="853" alt="after" src="https://github.com/user-attachments/assets/9d216207-25d7-4947-8dc4-3018119ee88b" />

**After** with fewer menu items:
<img width="1048" height="851" alt="after with fewer menu items" src="https://github.com/user-attachments/assets/9eb2f38b-222f-462d-bce5-b864087488eb" />

Tested this in the skeleton gamemode. Scrolling works great with both the mouse wheel and that scrollbar grip.

