### PR TITLE
Fix PerformInteraction initiating action, but not finishing it, due to inconsistent tracing

### DIFF
--- a/gamemode/core/meta/sh_player.lua
+++ b/gamemode/core/meta/sh_player.lua
@@ -241,15 +241,11 @@ if (SERVER) then
 			timer.Create("ixCharacterInteraction" .. self:SteamID(), time, 1, function()
 				if (IsValid(self) and IsValid(entity) and IsValid(self.ixInteractionTarget) and
 					self.ixInteractionCharacter == self:GetCharacter():GetID()) then
-					local data = {}
-						data.start = self:GetShootPos()
-						data.endpos = data.start + self:GetAimVector() * 96
-						data.filter = self
-					local traceEntity = util.TraceLine(data).Entity
+					local useEntity = self:GetUseEntity()
 
-					if (IsValid(traceEntity) and traceEntity == self.ixInteractionTarget and !traceEntity.ixInteractionDirty) then
+					if (IsValid(useEntity) and useEntity == self.ixInteractionTarget and !useEntity.ixInteractionDirty) then
 						if (callback(self) != false) then
-							traceEntity.ixInteractionDirty = true
+							useEntity.ixInteractionDirty = true
 						end
 					end
 				end


### PR DESCRIPTION
In Helix the `playerMeta:PerformInteraction` function is only used in `ENT:Use`. `ENT:Use` internally resol `Player:GetUseEntity` to test which entity is being used, which does not neccessarily have to be exactly under the crosshair. 

Before this commit, the exact trace performed did not necessarily land on the same entity being used, meaning you could press USE to pickup an item and after the delay nothing would happen.

`PerformInteraction` is exclusively used in `ENT:Use` for these entities (which are thus the only internal ones affected by this PR):
* `ix_item`
* `ix_money`
* `ix_shipment`

## Before:
This gif shows me pressing USE (e) on the entity, initiating the interaction. However because I'm slightly off, the trace in the current code doesn't register this as successful. As I move the crosshair exactly over the item, it does register:
![gmod_YJSEWn4jVU-ezgif com-cut](https://github.com/user-attachments/assets/f49cd839-909e-45a4-957a-31867e12776c)

## After:
This gif shows that because we use `Player:GetUserEntity` in the `PerformInteraction` callback we get a trace consistent with the one that started it. We can pick up the item as expected, even though we are slightly off:
![gmod_oUhihoIpXe-ezgif com-cut](https://github.com/user-attachments/assets/ca693501-1069-42b3-ab57-1ffb46469417)

## Something to consider

This change removes the distance check performed by `self:GetAimVector() * 96`. I'm not entirely sure what the default range is in Garry's Mod (80 in Source SDK 2013) for using entities, but whatever it is that is the new range for picking up items. All I can say is that from my testing it feels a lot better, because the item not picking up sometimes (despite showing the loading indicator) felt jank.

If this fix is undesirable then an alternative fix would be: perform the same TraceLine in the current code, before initiating the interaction, causing for a consistent trace being used.

Code related to using entities in source-sdk-2013 (which Garry/Rubat might have changed):
https://github.com/ValveSoftware/source-sdk-2013/blob/68c8b82fdcb41b8ad5abde9fe1f0654254217b8e/src/game/shared/baseplayer_shared.h#L15
https://github.com/ValveSoftware/source-sdk-2013/blob/68c8b82fdcb41b8ad5abde9fe1f0654254217b8e/src/game/shared/baseplayer_shared.cpp#L1132

## A nice side effect

Something I see as positive is that according to my limited testing `GetUseEntity` is influenced by the `FindUseEntity` hook. This means the proposed change also allows Schema developers to influence how (from what distance/angle/entity/origin) items, money and shipments are USE'd more creatively:
```
] lua_run print(Entity(478))
> print(Entity(478))...
Entity [478][ix_item]

] lua_run hook.Add("FindUseEntity", "tesst", function(player,ent) return Entity(478) end)
> hook.Add("FindUseEntity", "tesst", function(player,ent) return Entity(478) end)...

] lua_run print(P1:GetUseEntity())
> print(P1:GetUseEntity())...
Entity [478][ix_item]
```