### PR TITLE
Add missing break in class loading loop

### DIFF
--- a/gamemode/core/libs/sh_class.lua
+++ b/gamemode/core/libs/sh_class.lua
@@ -32,6 +32,8 @@ function ix.class.LoadFromDir(directory)
 		for _, v2 in ipairs(ix.class.list) do
 			if (v2.uniqueID == niceName) then
 				halt = true
+
+                break
 			end
 		end
 


### PR DESCRIPTION
A break statement was added after detecting a duplicate uniqueID in the class loading loop to prevent unnecessary iterations.

This pull request makes a minor fix to the `ix.class.LoadFromDir` function in `gamemode/core/libs/sh_class.lua` by adding a `break` statement after setting the `halt` flag. This ensures the loop stops immediately once a matching `uniqueID` is found, improving efficiency.