### PR TITLE
Have base CanPlayerInteractEntity hook handle interact range check to allow plugin override

### DIFF
--- a/docs/hooks/plugin.lua
+++ b/docs/hooks/plugin.lua
@@ -199,7 +199,13 @@ end
 -- @param data Any data passed with the interaction option
 -- @treturn bool Whether or not to allow the player to interact with the entity
 -- @usage function PLUGIN:CanPlayerInteractEntity(client, entity, option, data)
--- 	return false -- Disallow interacting with any entity.
+--  if (entity:GetClass() == "my_big_entity" and entity:GetPos():Distance(client:GetPos()) < 192) then
+--    return true -- Force allow interacting if within larger than default interact range of large entity
+--  end
+--
+-- 	if (client:GetNetVar("drunk")) then
+--    return false -- Disallow interacting with an entity while drunk
+-- 	end
 -- end
 function CanPlayerInteractEntity(client, entity, option, data)
 end

--- a/gamemode/core/hooks/sv_hooks.lua
+++ b/gamemode/core/hooks/sv_hooks.lua
@@ -138,6 +138,10 @@ function GM:KeyRelease(client, key)
 	end
 end
 
+function GM:CanPlayerInteractEntity(client, entity, option, data)
+	return entity:GetPos():DistToSqr(client:GetPos()) <= 96 ^ 2
+end
+
 function GM:CanPlayerInteractItem(client, action, item, data)
 	if (client:IsRestricted()) then
 		return false

--- a/gamemode/core/libs/sh_menu.lua
+++ b/gamemode/core/libs/sh_menu.lua
@@ -72,9 +72,10 @@ else
 		local option = net.ReadString()
 		local data = net.ReadType()
 
-		if (!IsValid(entity) or !isstring(option) or
-			hook.Run("CanPlayerInteractEntity", client, entity, option, data) == false or
-			entity:GetPos():Distance(client:GetPos()) > 96) then
+		if (!IsValid(entity)
+			or !isstring(option)
+			or hook.Run("CanPlayerInteractEntity", client, entity, option, data) == false
+		) then
 			return
 		end
 


### PR DESCRIPTION
As discussed in: https://github.com/NebulousCloud/helix/pull/483#issuecomment-3228560091
> [...] I suggest that instead of just a configuration option a default `CanPlayerInteractEntity` hook implementation should do the range check, e.g: in `helix/gamemode/core/hooks/sv_hooks.lua`:
> 
> ```lua
> function GM:CanPlayerInteractEntity(client, entity, option, data)
>   return entity:GetPos():Distance(client:GetPos()) <= 96
> end
> ```
> 
> Or with the configuration proposed in this PR:
> 
> ```lua
> function GM:CanPlayerInteractEntity(client, entity, option, data)
>   local configDistanceSqr = ix.config.Get("interactionRange", 96) ^ 2
>   return entity:GetPos():DistToSqr(client:GetPos()) <= configDistanceSqr
> end
> ```
> 
> That way schemas and plugins can force specific entities to be allowed:
> 
> ```lua
> function Schema:CanPlayerInteractEntity(client, entity, option, menu)
>   if(entity:GetClass() == "my_big_entity" and entity:GetPos():Distance(client:GetPos()) < 128) then
>     return true -- force allow
>   end
> end
> ```

Although @Lucasgood5's idea (#483) for a interactionRange configuration is something I'd like to see, I've chosen to not implement it in this PR. This is because, after searching in the framework, we may want to consider implementing that config that in all places the `96` number is used (as [mentioned by Lucasgood5](https://github.com/NebulousCloud/helix/pull/498#pullrequestreview-3125947873)):
<img width="361" height="799" alt="VSCode search results showing for 96 search" src="https://github.com/user-attachments/assets/a3264fb9-c16b-44e6-b2af-b44a7b56a253" />
