### PR TITLE
Improve model selection for bot character spawn

### DIFF
--- a/gamemode/core/hooks/sv_hooks.lua
+++ b/gamemode/core/hooks/sv_hooks.lua
@@ -9,10 +9,17 @@ function GM:PlayerInitialSpawn(client)
 		local index = math.random(1, table.Count(ix.faction.indices))
 		local faction = ix.faction.indices[index]
 
+        local models = faction:GetModels( client )
+
+        local model = models[ math.random( #models ) ]
+        if ( istable( model ) ) then model = model[ 1 ] end
+
+        if ( !isstring( model ) ) then model = "models/gman.mdl" end
+
 		local character = ix.char.New({
 			name = client:Name(),
 			faction = faction and faction.uniqueID or "unknown",
-			model = faction and table.Random(faction:GetModels(client)) or "models/gman.mdl"
+			model = model,
 		}, botID, client, client:SteamID64())
 		character.isBot = true
 


### PR DESCRIPTION
Refines the logic for selecting a model when spawning a bot character. Ensures the selected model is a valid string and defaults to 'models/gman.mdl' if not, improving reliability and preventing errors with invalid model types.

This pull request updates the player initialization logic to make the selection of a character model more robust and error-resistant. The main improvement is a safer process for choosing a model for new players, ensuring that the selected model is always a valid string and providing a fallback if necessary.

**Player model selection improvements:**

* Refactored the model selection in `GM:PlayerInitialSpawn` to explicitly choose a random model from the list returned by `faction:GetModels(client)`, handle cases where the model is a table (by selecting the first element), and default to `"models/gman.mdl"` if the result is not a string.