### PR TITLE
Add "Interaction Distance" config setting

### DIFF
--- a/entities/weapons/ix_hands.lua
+++ b/entities/weapons/ix_hands.lua
@@ -449,7 +449,7 @@ function SWEP:SecondaryAttack()
 
 	local data = {}
 		data.start = self:GetOwner():GetShootPos()
-		data.endpos = data.start + self:GetOwner():GetAimVector() * 84
+		data.endpos = data.start + self:GetOwner():GetAimVector() * (self.maxHoldDistance * 0.875)
 		data.filter = {self, self:GetOwner()}
 	local trace = util.TraceLine(data)
 	local entity = trace.Entity

--- a/entities/weapons/ix_hands.lua
+++ b/entities/weapons/ix_hands.lua
@@ -61,7 +61,9 @@ function SWEP:Initialize()
 	self:SetHoldType(self.HoldType)
 
 	self.lastHand = 0
-	self.maxHoldDistance = ix.config.Get("interactionDistance", 96) -- how far away the held object is allowed to travel before forcefully dropping
+
+	-- how far away the held object is allowed to travel before forcefully dropping
+	self.maxHoldDistance = ix.config.Get("interactionDistance", 96)
 	self.maxHoldDistanceSquared = self.maxHoldDistance ^ 2
 	self.heldObjectAngle = Angle(angle_zero)
 end

--- a/entities/weapons/ix_hands.lua
+++ b/entities/weapons/ix_hands.lua
@@ -63,7 +63,7 @@ function SWEP:Initialize()
 	self.lastHand = 0
 
 	-- how far away the held object is allowed to travel before forcefully dropping
-	self.maxHoldDistance = ix.config.Get("interactionDistance", 96)
+	self.maxHoldDistance = ix.config.Get("interactRange", 96)
 	self.maxHoldDistanceSquared = self.maxHoldDistance ^ 2
 	self.heldObjectAngle = Angle(angle_zero)
 end
@@ -417,7 +417,7 @@ function SWEP:PrimaryAttack()
 			self:GetOwner():LagCompensation(true)
 				local data = {}
 					data.start = self:GetOwner():GetShootPos()
-					data.endpos = data.start + self:GetOwner():GetAimVector() * ix.config.Get("interactionDistance", 96)
+					data.endpos = data.start + self:GetOwner():GetAimVector() * ix.config.Get("interactRange", 96)
 					data.filter = self:GetOwner()
 				local trace = util.TraceLine(data)
 

--- a/entities/weapons/ix_hands.lua
+++ b/entities/weapons/ix_hands.lua
@@ -51,7 +51,6 @@ SWEP.FireWhenLowered = true
 SWEP.HoldType = "fist"
 
 SWEP.holdDistance = 64
-SWEP.maxHoldDistance = 96 -- how far away the held object is allowed to travel before forcefully dropping
 SWEP.maxHoldStress = 4000 -- how much stress the held object can undergo before forcefully dropping
 
 -- luacheck: globals ACT_VM_FISTS_DRAW ACT_VM_FISTS_HOLSTER
@@ -62,6 +61,7 @@ function SWEP:Initialize()
 	self:SetHoldType(self.HoldType)
 
 	self.lastHand = 0
+	self.maxHoldDistance = ix.config.Get("interactionDistance", 96) -- how far away the held object is allowed to travel before forcefully dropping
 	self.maxHoldDistanceSquared = self.maxHoldDistance ^ 2
 	self.heldObjectAngle = Angle(angle_zero)
 end
@@ -415,7 +415,7 @@ function SWEP:PrimaryAttack()
 			self:GetOwner():LagCompensation(true)
 				local data = {}
 					data.start = self:GetOwner():GetShootPos()
-					data.endpos = data.start + self:GetOwner():GetAimVector() * 96
+					data.endpos = data.start + self:GetOwner():GetAimVector() * ix.config.Get("interactionDistance", 96)
 					data.filter = self:GetOwner()
 				local trace = util.TraceLine(data)
 

--- a/gamemode/config/sh_config.lua
+++ b/gamemode/config/sh_config.lua
@@ -182,8 +182,16 @@ ix.config.Add("itemPickupTime", 0.5, "How long it takes to pick up and put an it
 	data = {min = 0, max = 5, decimals = 1},
 	category = "interaction"
 })
-ix.config.Add("interactionDistance", 96, "The maximum distance a player can be in order to interact with an item or entity.", nil, {
-	data = {min = 1, max = 256},
+ix.config.Add("interactionDistance", 96, "The maximum distance a player can be in order to interact with an item or entity.", function(oldValue, newValue)
+	for _, v in player.Iterator() do
+		local wep = v:GetWeapon("ix_hands")
+		if IsValid(wep) then
+			wep.maxHoldDistance = newValue
+			wep.maxHoldDistanceSquared = newValue ^ 2
+		end
+	end
+end, {
+	data = {min = 48, max = 96},
 	category = "interaction"
 })
 ix.config.Add("year", 2015, "The current in-game year.", function(oldValue, newValue)

--- a/gamemode/config/sh_config.lua
+++ b/gamemode/config/sh_config.lua
@@ -182,7 +182,7 @@ ix.config.Add("itemPickupTime", 0.5, "How long it takes to pick up and put an it
 	data = {min = 0, max = 5, decimals = 1},
 	category = "interaction"
 })
-ix.config.Add("interactionDistance", 96, "The maximum distance that entities can be interacted with.", function(old, new)
+ix.config.Add("interactRange", 96, "The maximum distance that entities can be interacted with.", function(old, new)
 	for _, v in player.Iterator() do
 		local wep = v:GetWeapon("ix_hands")
 		if IsValid(wep) then

--- a/gamemode/config/sh_config.lua
+++ b/gamemode/config/sh_config.lua
@@ -182,12 +182,12 @@ ix.config.Add("itemPickupTime", 0.5, "How long it takes to pick up and put an it
 	data = {min = 0, max = 5, decimals = 1},
 	category = "interaction"
 })
-ix.config.Add("interactionDistance", 96, "The maximum distance a player can be in order to interact with an item or entity.", function(oldValue, newValue)
+ix.config.Add("interactionDistance", 96, "The maximum distance that entities can be interacted with.", function(old, new)
 	for _, v in player.Iterator() do
 		local wep = v:GetWeapon("ix_hands")
 		if IsValid(wep) then
-			wep.maxHoldDistance = newValue
-			wep.maxHoldDistanceSquared = newValue ^ 2
+			wep.maxHoldDistance = new
+			wep.maxHoldDistanceSquared = new ^ 2
 		end
 	end
 end, {

--- a/gamemode/config/sh_config.lua
+++ b/gamemode/config/sh_config.lua
@@ -182,6 +182,10 @@ ix.config.Add("itemPickupTime", 0.5, "How long it takes to pick up and put an it
 	data = {min = 0, max = 5, decimals = 1},
 	category = "interaction"
 })
+ix.config.Add("interactionDistance", 96, "The maximum distance a player can be in order to interact with an item or entity.", nil, {
+	data = {min = 1, max = 256},
+	category = "interaction"
+})
 ix.config.Add("year", 2015, "The current in-game year.", function(oldValue, newValue)
 	if (SERVER and !ix.date.bSaving) then
 		ix.date.ResolveOffset()

--- a/gamemode/core/hooks/cl_hooks.lua
+++ b/gamemode/core/hooks/cl_hooks.lua
@@ -737,7 +737,7 @@ function GM:KeyRelease(client, key)
 		if (!ix.menu.IsOpen()) then
 			local data = {}
 			data.start = client:GetShootPos()
-			data.endpos = data.start + client:GetAimVector() * 96
+			data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactionDistance", 96)
 			data.filter = client
 
 			local entity = util.TraceLine(data).Entity
@@ -763,7 +763,7 @@ function GM:PlayerBindPress(client, bind, pressed)
 		if (pickupTime > 0) then
 			local data = {}
 				data.start = client:GetShootPos()
-				data.endpos = data.start + client:GetAimVector() * 96
+				data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactionDistance", 96)
 				data.filter = client
 			local entity = util.TraceLine(data).Entity
 

--- a/gamemode/core/hooks/cl_hooks.lua
+++ b/gamemode/core/hooks/cl_hooks.lua
@@ -737,7 +737,7 @@ function GM:KeyRelease(client, key)
 		if (!ix.menu.IsOpen()) then
 			local data = {}
 			data.start = client:GetShootPos()
-			data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactionDistance", 96)
+			data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactRange", 96)
 			data.filter = client
 
 			local entity = util.TraceLine(data).Entity
@@ -763,7 +763,7 @@ function GM:PlayerBindPress(client, bind, pressed)
 		if (pickupTime > 0) then
 			local data = {}
 				data.start = client:GetShootPos()
-				data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactionDistance", 96)
+				data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactRange", 96)
 				data.filter = client
 			local entity = util.TraceLine(data).Entity
 

--- a/gamemode/core/hooks/sv_hooks.lua
+++ b/gamemode/core/hooks/sv_hooks.lua
@@ -121,7 +121,7 @@ function GM:KeyPress(client, key)
 	elseif (key == IN_USE) then
 		local data = {}
 			data.start = client:GetShootPos()
-			data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactionDistance", 96)
+			data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactRange", 96)
 			data.filter = client
 		local entity = util.TraceLine(data).Entity
 
@@ -146,7 +146,7 @@ function GM:KeyRelease(client, key)
 end
 
 function GM:CanPlayerInteractEntity(client, entity, option, data)
-	return entity:GetPos():DistToSqr(client:GetPos()) <= (ix.config.Get("interactionDistance", 96) ^ 2)
+	return entity:GetPos():DistToSqr(client:GetPos()) <= (ix.config.Get("interactRange", 96) ^ 2)
 end
 
 function GM:CanPlayerInteractItem(client, action, item, data)
@@ -822,7 +822,7 @@ end
 function GM:PlayerCanPickupWeapon(client, weapon)
 	local data = {}
 		data.start = client:GetShootPos()
-		data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactionDistance", 96)
+		data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactRange", 96)
 		data.filter = client
 	local trace = util.TraceLine(data)
 

--- a/gamemode/core/hooks/sv_hooks.lua
+++ b/gamemode/core/hooks/sv_hooks.lua
@@ -121,7 +121,7 @@ function GM:KeyPress(client, key)
 	elseif (key == IN_USE) then
 		local data = {}
 			data.start = client:GetShootPos()
-			data.endpos = data.start + client:GetAimVector() * 96
+			data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactionDistance", 96)
 			data.filter = client
 		local entity = util.TraceLine(data).Entity
 
@@ -146,7 +146,8 @@ function GM:KeyRelease(client, key)
 end
 
 function GM:CanPlayerInteractEntity(client, entity, option, data)
-	return entity:GetPos():DistToSqr(client:GetPos()) <= 96 ^ 2
+	local intDist = ix.config.Get("interactionDistance", 96)
+	return entity:GetPos():DistToSqr(client:GetPos()) <= intDist ^ 2
 end
 
 function GM:CanPlayerInteractItem(client, action, item, data)
@@ -822,7 +823,7 @@ end
 function GM:PlayerCanPickupWeapon(client, weapon)
 	local data = {}
 		data.start = client:GetShootPos()
-		data.endpos = data.start + client:GetAimVector() * 96
+		data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactionDistance", 96)
 		data.filter = client
 	local trace = util.TraceLine(data)
 

--- a/gamemode/core/hooks/sv_hooks.lua
+++ b/gamemode/core/hooks/sv_hooks.lua
@@ -146,8 +146,7 @@ function GM:KeyRelease(client, key)
 end
 
 function GM:CanPlayerInteractEntity(client, entity, option, data)
-	local intDist = ix.config.Get("interactionDistance", 96)
-	return entity:GetPos():DistToSqr(client:GetPos()) <= intDist ^ 2
+	return entity:GetPos():DistToSqr(client:GetPos()) <= (ix.config.Get("interactionDistance", 96) ^ 2)
 end
 
 function GM:CanPlayerInteractItem(client, action, item, data)

--- a/gamemode/core/libs/sh_item.lua
+++ b/gamemode/core/libs/sh_item.lua
@@ -621,8 +621,7 @@ do
 			end
 
 			if (item.entity) then
-				local intDist = ix.config.Get("interactionDistance", 96)
-				if (client:GetShootPos():DistToSqr(item.entity:GetPos()) > intDist * intDist) then
+				if (client:GetShootPos():DistToSqr(item.entity:GetPos()) > (ix.config.Get("interactionDistance", 96) ^ 2)) then
 					return
 				end
 

--- a/gamemode/core/libs/sh_item.lua
+++ b/gamemode/core/libs/sh_item.lua
@@ -621,7 +621,7 @@ do
 			end
 
 			if (item.entity) then
-				if (client:GetShootPos():DistToSqr(item.entity:GetPos()) > (ix.config.Get("interactionDistance", 96) ^ 2)) then
+				if (client:GetShootPos():DistToSqr(item.entity:GetPos()) > (ix.config.Get("interactRange", 96) ^ 2)) then
 					return
 				end
 

--- a/gamemode/core/libs/sh_item.lua
+++ b/gamemode/core/libs/sh_item.lua
@@ -621,7 +621,8 @@ do
 			end
 
 			if (item.entity) then
-				if (client:GetShootPos():DistToSqr(item.entity:GetPos()) > 96 * 96) then
+				local intDist = ix.config.Get("interactionDistance", 96)
+				if (client:GetShootPos():DistToSqr(item.entity:GetPos()) > intDist * intDist) then
 					return
 				end
 

--- a/gamemode/core/meta/sh_player.lua
+++ b/gamemode/core/meta/sh_player.lua
@@ -137,7 +137,7 @@ function meta:DoStaredAction(entity, callback, time, onCancel, distance)
 	timer.Create(uniqueID, 0.1, time / 0.1, function()
 		if (IsValid(self) and IsValid(entity)) then
 			data.start = self:GetShootPos()
-			data.endpos = data.start + self:GetAimVector() * (distance or ix.config.Get("interactionDistance", 96))
+			data.endpos = data.start + self:GetAimVector() * (distance or ix.config.Get("interactRange", 96))
 
 			if (util.TraceLine(data).Entity != entity) then
 				timer.Remove(uniqueID)

--- a/gamemode/core/meta/sh_player.lua
+++ b/gamemode/core/meta/sh_player.lua
@@ -137,7 +137,7 @@ function meta:DoStaredAction(entity, callback, time, onCancel, distance)
 	timer.Create(uniqueID, 0.1, time / 0.1, function()
 		if (IsValid(self) and IsValid(entity)) then
 			data.start = self:GetShootPos()
-			data.endpos = data.start + self:GetAimVector()*(distance or 96)
+			data.endpos = data.start + self:GetAimVector() * (distance or ix.config.Get("interactionDistance", 96))
 
 			if (util.TraceLine(data).Entity != entity) then
 				timer.Remove(uniqueID)

--- a/gamemode/core/sh_commands.lua
+++ b/gamemode/core/sh_commands.lua
@@ -437,7 +437,7 @@ do
 
 				local data = {}
 					data.start = client:GetShootPos()
-					data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactionDistance", 96)
+					data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactRange", 96)
 					data.filter = client
 				local target = util.TraceLine(data).Entity
 

--- a/gamemode/core/sh_commands.lua
+++ b/gamemode/core/sh_commands.lua
@@ -437,7 +437,7 @@ do
 
 				local data = {}
 					data.start = client:GetShootPos()
-					data.endpos = data.start + client:GetAimVector() * 96
+					data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactionDistance", 96)
 					data.filter = client
 				local target = util.TraceLine(data).Entity
 

--- a/plugins/area/cl_plugin.lua
+++ b/plugins/area/cl_plugin.lua
@@ -6,7 +6,7 @@ function PLUGIN:GetPlayerAreaTrace()
 
 	return util.TraceLine({
 		start = client:GetShootPos(),
-		endpos = client:GetShootPos() + client:GetForward() * ix.config.Get("interactionDistance", 96),
+		endpos = client:GetShootPos() + client:GetForward() * ix.config.Get("interactRange", 96),
 		filter = client
 	})
 end

--- a/plugins/area/cl_plugin.lua
+++ b/plugins/area/cl_plugin.lua
@@ -6,7 +6,7 @@ function PLUGIN:GetPlayerAreaTrace()
 
 	return util.TraceLine({
 		start = client:GetShootPos(),
-		endpos = client:GetShootPos() + client:GetForward() * 96,
+		endpos = client:GetShootPos() + client:GetForward() * ix.config.Get("interactionDistance", 96),
 		filter = client
 	})
 end

--- a/plugins/doors/entities/weapons/ix_keys.lua
+++ b/plugins/doors/entities/weapons/ix_keys.lua
@@ -86,7 +86,7 @@ function SWEP:PrimaryAttack()
 
 	local data = {}
 		data.start = self.Owner:GetShootPos()
-		data.endpos = data.start + self.Owner:GetAimVector()*96
+		data.endpos = data.start + self.Owner:GetAimVector() * ix.config.Get("interactionDistance", 96)
 		data.filter = self.Owner
 	local entity = util.TraceLine(data).Entity
 
@@ -110,7 +110,7 @@ function SWEP:PrimaryAttack()
 end
 
 function SWEP:ToggleLock(door, state)
-	if (IsValid(self.Owner) and self.Owner:GetPos():Distance(door:GetPos()) > 96) then
+	if (IsValid(self.Owner) and self.Owner:GetPos():Distance(door:GetPos()) > ix.config.Get("interactionDistance", 96)) then
 		return
 	end
 
@@ -176,7 +176,7 @@ function SWEP:SecondaryAttack()
 
 	local data = {}
 		data.start = self.Owner:GetShootPos()
-		data.endpos = data.start + self.Owner:GetAimVector()*96
+		data.endpos = data.start + self.Owner:GetAimVector() * ix.config.Get("interactionDistance", 96)
 		data.filter = self.Owner
 	local entity = util.TraceLine(data).Entity
 

--- a/plugins/doors/entities/weapons/ix_keys.lua
+++ b/plugins/doors/entities/weapons/ix_keys.lua
@@ -86,7 +86,7 @@ function SWEP:PrimaryAttack()
 
 	local data = {}
 		data.start = self.Owner:GetShootPos()
-		data.endpos = data.start + self.Owner:GetAimVector() * ix.config.Get("interactionDistance", 96)
+		data.endpos = data.start + self.Owner:GetAimVector() * ix.config.Get("interactRange", 96)
 		data.filter = self.Owner
 	local entity = util.TraceLine(data).Entity
 
@@ -110,7 +110,7 @@ function SWEP:PrimaryAttack()
 end
 
 function SWEP:ToggleLock(door, state)
-	if (IsValid(self.Owner) and self.Owner:GetPos():Distance(door:GetPos()) > ix.config.Get("interactionDistance", 96)) then
+	if (IsValid(self.Owner) and self.Owner:GetPos():Distance(door:GetPos()) > ix.config.Get("interactRange", 96)) then
 		return
 	end
 
@@ -176,7 +176,7 @@ function SWEP:SecondaryAttack()
 
 	local data = {}
 		data.start = self.Owner:GetShootPos()
-		data.endpos = data.start + self.Owner:GetAimVector() * ix.config.Get("interactionDistance", 96)
+		data.endpos = data.start + self.Owner:GetAimVector() * ix.config.Get("interactRange", 96)
 		data.filter = self.Owner
 	local entity = util.TraceLine(data).Entity
 

--- a/plugins/doors/sh_commands.lua
+++ b/plugins/doors/sh_commands.lua
@@ -4,10 +4,10 @@ local PLUGIN = PLUGIN
 ix.command.Add("DoorSell", {
 	description = "@cmdDoorSell",
 	OnRun = function(self, client, arguments)
-		-- Get the entity 96 units infront of the player.
+		-- Get the entity intDist units infront of the player.
 		local data = {}
 			data.start = client:GetShootPos()
-			data.endpos = data.start + client:GetAimVector() * 96
+			data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactionDistance", 96)
 			data.filter = client
 		local trace = util.TraceLine(data)
 		local entity = trace.Entity
@@ -55,10 +55,10 @@ ix.command.Add("DoorSell", {
 ix.command.Add("DoorBuy", {
 	description = "@cmdDoorBuy",
 	OnRun = function(self, client, arguments)
-		-- Get the entity 96 units infront of the player.
+		-- Get the entity intDist units infront of the player.
 		local data = {}
 			data.start = client:GetShootPos()
-			data.endpos = data.start + client:GetAimVector() * 96
+			data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactionDistance", 96)
 			data.filter = client
 		local trace = util.TraceLine(data)
 		local entity = trace.Entity
@@ -281,7 +281,7 @@ ix.command.Add("DoorSetTitle", {
 		-- Get the door infront of the player.
 		local data = {}
 			data.start = client:GetShootPos()
-			data.endpos = data.start + client:GetAimVector() * 96
+			data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactionDistance", 96)
 			data.filter = client
 		local trace = util.TraceLine(data)
 		local entity = trace.Entity

--- a/plugins/doors/sh_commands.lua
+++ b/plugins/doors/sh_commands.lua
@@ -7,7 +7,7 @@ ix.command.Add("DoorSell", {
 		-- Get the entity intDist units infront of the player.
 		local data = {}
 			data.start = client:GetShootPos()
-			data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactionDistance", 96)
+			data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactRange", 96)
 			data.filter = client
 		local trace = util.TraceLine(data)
 		local entity = trace.Entity
@@ -58,7 +58,7 @@ ix.command.Add("DoorBuy", {
 		-- Get the entity intDist units infront of the player.
 		local data = {}
 			data.start = client:GetShootPos()
-			data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactionDistance", 96)
+			data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactRange", 96)
 			data.filter = client
 		local trace = util.TraceLine(data)
 		local entity = trace.Entity
@@ -281,7 +281,7 @@ ix.command.Add("DoorSetTitle", {
 		-- Get the door infront of the player.
 		local data = {}
 			data.start = client:GetShootPos()
-			data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactionDistance", 96)
+			data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactRange", 96)
 			data.filter = client
 		local trace = util.TraceLine(data)
 		local entity = trace.Entity

--- a/plugins/doors/sv_plugin.lua
+++ b/plugins/doors/sv_plugin.lua
@@ -194,7 +194,7 @@ end
 function PLUGIN:ShowTeam(client)
 	local data = {}
 		data.start = client:GetShootPos()
-		data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactionDistance", 96)
+		data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactRange", 96)
 		data.filter = client
 	local trace = util.TraceLine(data)
 	local entity = trace.Entity

--- a/plugins/doors/sv_plugin.lua
+++ b/plugins/doors/sv_plugin.lua
@@ -194,7 +194,7 @@ end
 function PLUGIN:ShowTeam(client)
 	local data = {}
 		data.start = client:GetShootPos()
-		data.endpos = data.start + client:GetAimVector() * 96
+		data.endpos = data.start + client:GetAimVector() * ix.config.Get("interactionDistance", 96)
 		data.filter = client
 	local trace = util.TraceLine(data)
 	local entity = trace.Entity


### PR DESCRIPTION
Standardized all 96 unit interaction checks with a config variable (defaulting to 96 still) that allows for plugins to use a standard scalar for all interaction checks. 

Note that you can't go OVER this value, as ENT:Use() has a hardcoded distance at the engine level of 96 Hammer units (technically 82, but 14 units is not worth dealing with compatibility issues over). I also set a few other literals that were derived from this distance mathematically but not explicitly, such as ix_hands' secondary attack range.

Taken from a handful of other PRs with similar ideas that did not implement it evenly or modified other parameters as well.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a configurable interaction range, adjustable from 48 to 96 units.
  - Applied the setting consistently across item, entity, door, vehicle, weapon, area and money-transfer interactions.
  - Updated hand-held interactions to respect the configured range.

- **Bug Fixes**
  - Removed inconsistent fixed-distance checks, ensuring interaction targeting uses the selected range throughout the game.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->