### PR TITLE
Enhance Italics Support in Chatbox

### DIFF
--- a/gamemode/core/libs/sh_chatbox.lua
+++ b/gamemode/core/libs/sh_chatbox.lua
@@ -281,12 +281,22 @@ end
 function ix.chat.Format(text)
 	text = string.Trim(text)
 	local last = text:utf8sub(-1)
+	local check = (last == "*" and text:utf8sub(-2, -2)) or last
 
-	if (last != "." and last != "?" and last != "!" and last != "-" and last != "\"") then
-		text = text .. "."
+	if (check != "." and check != "?" and check != "!" and check != "-" and check != "\"") then
+		if (last == "*") then
+			text = text:utf8sub(1, -2) .. ".*"
+		else
+			text = text .. "."
+		end
 	end
 
-	return text:utf8sub(1, 1):utf8upper() .. text:utf8sub(2)
+	local first = text:utf8sub(1, 1)
+	if (first == "*") then
+		return first .. text:utf8sub(2, 2):utf8upper() .. text:utf8sub(3)
+	else
+		return text:utf8sub(1, 1):utf8upper() .. text:utf8sub(2)
+	end
 end
 
 if (SERVER) then

--- a/plugins/chatbox/derma/cl_chatbox.lua
+++ b/plugins/chatbox/derma/cl_chatbox.lua
@@ -341,7 +341,13 @@ function PANEL:AddLine(elements, bShouldScroll)
 				local inner = value:utf8sub(2, -2)
 
 				if (inner:find("%S")) then
-					return "<font=ixChatFontItalics>" .. value:utf8sub(2, -2) .. "</font>"
+					local baseFont = (CHAT_CLASS and CHAT_CLASS.font) or "ixChatFont"
+					local italicsFont = baseFont .. "Italics"
+					if !pcall(surface.SetFont, italicsFont) then
+						italicsFont = "ixChatFontItalics"
+					end
+
+					return "<font=" .. italicsFont .. ">" .. inner .. "</font>"
 				end
 			end)
 		end


### PR DESCRIPTION
1) Adjusted ix.chat.Format() for autoformatted chat classes such that using asterisks (for italics) will still capitalize the first non-asterisk character properly, and not append an extra period when the second to last character was valid punctuation.

2) Added a check inside of the cl_chatbox.lua derma where the italics font is applied to see if the chat class' font has a variant that ends in "Italics" to use; will fall back to ixChatFontItalics as usual if it does not exist.