### PR TITLE
Add CHAT_CLASS:GetFont(), Use "data" in PlayerMessageSend

### DIFF
--- a/docs/hooks/plugin.lua
+++ b/docs/hooks/plugin.lua
@@ -846,11 +846,12 @@ end
 -- @bool anonymous Whether or not message was anonymous
 -- @tab receivers Players who will hear that message
 -- @string rawText Chat message without any formatting
+-- @tab data The data table sent with the chat message
 -- @treturn string You can return text that will be shown instead
 -- @usage function PLUGIN:PlayerMessageSend(speaker, chatType, text, anonymous, receivers, rawText)
 --  return "Text" -- When a player writes something into chat, he will say "Text" instead.
 -- end
-function PlayerMessageSend(speaker, chatType, text, anonymous, receivers, rawText)
+function PlayerMessageSend(speaker, chatType, text, anonymous, receivers, rawText, data)
 end
 
 --- Called when a player model was changed.

--- a/gamemode/core/libs/sh_chatbox.lua
+++ b/gamemode/core/libs/sh_chatbox.lua
@@ -80,6 +80,12 @@ Name = "Helix - Bypass OOC Timer",
 -- 		-- each message with this chat class will be colored a random shade of red
 -- 		return Color(math.random(120, 200), 0, 0)
 -- 	end
+-- @field[type=function,opt] GetFont Function to run to set the font of a message with this chat class. You should generally
+-- stick to using `font`, but this is useful for when you want the font of the message to change with some criteria.
+-- 	GetFont = function(self, speaker, text, data)
+-- 		-- each message with this chat class will use whatever the `w` class uses, or the standard fallback `ixChatFont`.
+-- 		return ix.chat.classes.w.font or "ixChatFont"
+-- 	end
 -- @field[type=function,opt] OnChatAdd Function to run when a message with this chat class should be added to the chatbox. If
 -- using this function, make sure you end the function by calling `chat.AddText` in order for the text to show up.
 --
@@ -261,7 +267,7 @@ function ix.chat.Parse(client, message, bNoSend)
 	-- Only send if needed.
 	if (SERVER and !bNoSend) then
 		-- Send the correct chat type out so other player see the message.
-		ix.chat.Send(client, chatType, hook.Run("PlayerMessageSend", client, chatType, message, anonymous) or message, anonymous)
+		ix.chat.Send(client, chatType, message, anonymous)
 	end
 
 	-- Return the chosen chat type and the message that was sent if needed for some reason.
@@ -354,7 +360,7 @@ if (SERVER) then
 				text = ix.chat.Format(text)
 			end
 
-			text = hook.Run("PlayerMessageSend", speaker, chatType, text, bAnonymous, receivers, rawText) or text
+			text = hook.Run("PlayerMessageSend", speaker, chatType, text, bAnonymous, receivers, rawText, data) or text
 
 			net.Start("ixChatMessage")
 				net.WriteEntity(speaker)
@@ -377,6 +383,7 @@ else
 
 			-- luacheck: globals CHAT_CLASS
 			CHAT_CLASS = class
+				CHAT_CLASS.font = (class.GetFont and class:GetFont(speaker, text, data)) or class.font or "ixChatFont"
 				class:OnChatAdd(speaker, text, anonymous, data)
 			CHAT_CLASS = nil
 		end


### PR DESCRIPTION
1) Previously, chat classes could only have a static "font" string set. CLASS:GetFont() allows for dynamic fonts based on the speaker, text, or message data, without breaking compatibility; fallback order is CLASS:GetFont() (if it exists) --> CLASS.font (if it exists) --> "ixChatFont", the standard default. The placement is a bit odd, but it needs to be able to access speaker, text, and data.

2) ix.chat.Send's data table (or an empty table) is now passed as an argument at the end of PlayerMessageSend, so it can be used to modify the returned text. Backwards compatible.

3) Removed a duplicate PlayerMessageSend hook call from ix.chat.Parse; ix.chat.Send already calls it internally, so it was just running the hook twice for the same result.

4) Added documentation for all changes and additions.