### PR TITLE
fix(items): prevent item duplication bug and orphaned bot data

### DIFF
--- a/gamemode/core/libs/sh_item.lua
+++ b/gamemode/core/libs/sh_item.lua
@@ -60,8 +60,23 @@ function ix.item.Instance(index, uniqueID, itemData, x, y, callback, characterID
 	if (!uniqueID or ix.item.list[uniqueID]) then
 		itemData = istable(itemData) and itemData or {}
 
+		local inventory = ix.item.inventories[index]
+		local isTemp = inventory and inventory.noSave
+
+		-- Explicitly verify if the target inventory belongs to a bot character
+		local isBot = false
+		if (inventory and inventory.owner) then
+			local character = ix.char.loaded[inventory.owner]
+			if (character and character.isBot) then
+				isBot = true
+			end
+		end
+
+		local dbIndex = isTemp and 0 or index
+		local dbPlayerID = isBot and "BOT_ITEM" or playerID
+
 		local query = mysql:Insert("ix_items")
-			query:Insert("inventory_id", index)
+			query:Insert("inventory_id", dbIndex)
 			query:Insert("unique_id", uniqueID)
 			query:Insert("data", util.TableToJSON(itemData))
 			query:Insert("x", x)
@@ -71,8 +86,8 @@ function ix.item.Instance(index, uniqueID, itemData, x, y, callback, characterID
 				query:Insert("character_id", characterID)
 			end
 
-			if (playerID) then
-				query:Insert("player_id", playerID)
+			if (dbPlayerID) then
+				query:Insert("player_id", dbPlayerID)
 			end
 
 			query:Callback(function(result, status, lastID)

--- a/gamemode/core/libs/sh_item.lua
+++ b/gamemode/core/libs/sh_item.lua
@@ -97,7 +97,7 @@ function ix.item.Instance(index, uniqueID, itemData, x, y, callback, characterID
 					item.data = table.Copy(itemData)
 					item.invID = index
 					item.characterID = characterID
-					item.playerID = playerID
+					item.playerID = dbPlayerID
 
 					if (callback) then
 						callback(item)

--- a/gamemode/core/libs/sv_database.lua
+++ b/gamemode/core/libs/sv_database.lua
@@ -162,6 +162,60 @@ hook.Add("InitPostEntity", "ixDatabaseConnect", function()
 	ix.db.Connect()
 end)
 
+-- Garbage collection for bot inventories to prevent database bloat
+hook.Add("PostLoadData", "ixBotCleanup", function()
+	if (!mysql or !mysql.IsConnected or !mysql:IsConnected()) then return end
+
+	local query = mysql:Select("ix_items")
+	query:Select("item_id")
+	query:Select("unique_id")
+	query:Select("data")
+	query:Where("player_id", "BOT_ITEM")
+
+	query:Callback(function(result)
+		if (!istable(result) or #result == 0) then return end
+
+		local invsToDelete = {}
+		local itemsToDelete = {}
+		local jsonDecode = util.JSONToTable
+
+		for _, row in ipairs(result) do
+			table.insert(itemsToDelete, row.item_id)
+
+			local itemTable = ix.item.list[row.unique_id]
+			if (itemTable and itemTable.isBag) then
+				if (row.data and row.data != "" and row.data != "[]") then
+					local data = jsonDecode(row.data)
+
+					if (data and data.id) then
+						table.insert(invsToDelete, data.id)
+					end
+				end
+			end
+		end
+
+		if (#invsToDelete > 0) then
+			local delInvs = mysql:Delete("ix_inventories")
+			delInvs:WhereIn("inventory_id", invsToDelete)
+			delInvs:Execute()
+		end
+
+		if (#itemsToDelete > 0) then
+			local delItems = mysql:Delete("ix_items")
+			delItems:WhereIn("item_id", itemsToDelete)
+			delItems:Execute()
+		end
+
+		MsgC(Color(0, 255, 0),
+			string.format(
+				"[Helix] Wiped %d orphaned bot items and %d ghost bags from the database.\n",
+				#itemsToDelete, #invsToDelete
+			)
+		)
+	end)
+	query:Execute()
+end)
+
 local resetCalled = 0
 
 concommand.Add("ix_wipedb", function(client, cmd, arguments)

--- a/gamemode/core/libs/sv_database.lua
+++ b/gamemode/core/libs/sv_database.lua
@@ -195,6 +195,10 @@ hook.Add("PostLoadData", "ixBotCleanup", function()
 		end
 
 		if (#invsToDelete > 0) then
+			local delBagItems = mysql:Delete("ix_items")
+			delBagItems:WhereIn("inventory_id", invsToDelete)
+			delBagItems:Execute()
+
 			local delInvs = mysql:Delete("ix_inventories")
 			delInvs:WhereIn("inventory_id", invsToDelete)
 			delInvs:Execute()

--- a/gamemode/core/meta/sh_item.lua
+++ b/gamemode/core/meta/sh_item.lua
@@ -643,6 +643,37 @@ if (SERVER) then
 				local status, result = targetInv:Add(self.id, nil, nil, x, y, noReplication)
 
 				if (status) then
+					-- Check if the destination inventory is owned by a bot
+					local isBot = false
+					if (targetInv.owner) then
+						local character = ix.char.loaded[targetInv.owner]
+						if (character and character.isBot) then
+							isBot = true
+						end
+					end
+
+					-- Force database update for transient (noSave) inventories to prevent duplication
+					if (targetInv.noSave) then
+						local query = mysql:Update("ix_items")
+							query:Update("inventory_id", 0)
+							-- Only tag for deletion if it is specifically a bot, protecting real players
+							if (isBot) then
+								query:Update("player_id", "BOT_ITEM")
+							end
+							query:Where("item_id", self.id)
+						query:Execute()
+					elseif (curInv and curInv.noSave and IsValid(client) and client:GetCharacter()) then
+						-- Restore proper ownership when taking an item FROM a noSave inv TO a real player
+						self.playerID = client:SteamID64()
+						self.characterID = client:GetCharacter():GetID()
+
+						local query = mysql:Update("ix_items")
+							query:Update("player_id", self.playerID)
+							query:Update("character_id", self.characterID)
+							query:Where("item_id", self.id)
+						query:Execute()
+					end
+
 					if (self.invID > 0 and prevID != 0) then
 						-- we are transferring this item from one inventory to another
 						curInv:Remove(self.id, false, true, true)

--- a/gamemode/core/meta/sh_item.lua
+++ b/gamemode/core/meta/sh_item.lua
@@ -652,13 +652,15 @@ if (SERVER) then
 						end
 					end
 
-					-- Force database update for transient (noSave) inventories to prevent duplication
-					if (targetInv.noSave) then
+					-- Force database update for noSave inventories OR bot bags to prevent duplication
+					if (targetInv.noSave or isBot) then
 						local query = mysql:Update("ix_items")
-							query:Update("inventory_id", 0)
+							query:Update("inventory_id", targetInv.noSave and 0 or targetInv:GetID())
+
 							-- Only tag for deletion if it is specifically a bot, protecting real players
 							if (isBot) then
 								query:Update("player_id", "BOT_ITEM")
+								self.playerID = "BOT_ITEM"
 							end
 							query:Where("item_id", self.id)
 						query:Execute()

--- a/gamemode/core/meta/sh_item.lua
+++ b/gamemode/core/meta/sh_item.lua
@@ -664,8 +664,8 @@ if (SERVER) then
 							end
 							query:Where("item_id", self.id)
 						query:Execute()
-					elseif (curInv and curInv.noSave and IsValid(client) and client:GetCharacter()) then
-						-- Restore proper ownership when taking an item FROM a noSave inv TO a real player
+					elseif (curInv and (curInv.noSave or self.playerID == "BOT_ITEM") and IsValid(client) and client:GetCharacter()) then
+						-- Restore proper ownership when taking an item FROM noSave inv OR bot bag TO real player
 						self.playerID = client:SteamID64()
 						self.characterID = client:GetCharacter():GetID()
 


### PR DESCRIPTION
**Fix: item duplication & DB bloat when transferring to `noSave` inventories (bots)**

**Issue**  
Items moved to a bot's inventory reappeared in the original player's possession after restart due to the `mysql:Update` query being skipped entirely for `noSave` targets. This affected the HL2 RP schema, specifically /CharSearch command.

**Cause**  
The transfer logic treated `noSave` as a hard block on all DB writes, leaving the item's `inventory_id` unchanged. On save restore, the item was re‑linked to the original owner, causing duplication. Also garbage collection is ignored for temp bot data.

**Solution**  
- We now force the update query on transfer to `noSave`, setting `inventory_id = 0` (World) to detach the item from the previous owner without altering the target inventory.  
- Items instanced or moved to bots are tagged `player_id = "BOT_ITEM"`, and a new sweep in `PostLoadData` purges these bot‑owned items and ghost bags to prevent bloat.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved handling of items stored in temporary and bot-owned inventories.
- Kept item ownership and inventory records synchronised when items are transferred.
- Automatically removed temporary and bot-owned item records when saved data is loaded.
- Correctly restored ownership details when items move from temporary inventories to player characters.
- Prevented stale inventory data from remaining after bot-owned items and their contents are cleaned up.
- Improved consistency when items move between player, temporary and bot-owned storage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->