### PR TITLE
Add support for Networked Vars inside of the persistence plugin

### DIFF
--- a/plugins/persistence.lua
+++ b/plugins/persistence.lua
@@ -104,6 +104,14 @@ if (SERVER) then
 				entity:Spawn()
 				entity:Activate()
 
+				if (istable(v.NetworkVar)) then
+					for var, value in pairs(v.NetworkVar) do
+						local func = entity["Set" .. var]
+						if not isfunction(func) or value == nil then continue end
+						func(value)
+					end
+				end
+
 				if (v.bNoCollision) then
 					entity:SetCollisionGroup(COLLISION_GROUP_WORLD)
 				end
@@ -151,6 +159,7 @@ if (SERVER) then
 				data.Color = v:GetColor()
 				data.Material = v:GetMaterial()
 				data.bNoCollision = v:GetCollisionGroup() == COLLISION_GROUP_WORLD
+				data.NetworkVar = v.GetNetworkVars and v:GetNetworkVars() or nil
 
 				local materials = v:GetMaterials()
 

--- a/plugins/persistence.lua
+++ b/plugins/persistence.lua
@@ -104,13 +104,7 @@ if (SERVER) then
 				entity:Spawn()
 				entity:Activate()
 
-				if (istable(v.NetworkVar)) then
-					for var, value in pairs(v.NetworkVar) do
-						local func = entity["Set" .. var]
-						if not isfunction(func) or value == nil then continue end
-						func(value)
-					end
-				end
+				hook.Run("DoPersistanceLoad", entity, v)
 
 				if (v.bNoCollision) then
 					entity:SetCollisionGroup(COLLISION_GROUP_WORLD)
@@ -159,7 +153,8 @@ if (SERVER) then
 				data.Color = v:GetColor()
 				data.Material = v:GetMaterial()
 				data.bNoCollision = v:GetCollisionGroup() == COLLISION_GROUP_WORLD
-				data.NetworkVar = v.GetNetworkVars and v:GetNetworkVars() or nil
+
+				hook.Run("DoPersistanceSave", v, data)
 
 				local materials = v:GetMaterials()
 


### PR DESCRIPTION
Adding support for Networked Vars should be a minimum inside of a persistence plugin, Networked Vars are widely used by addons to save entity specific configurations on a entity.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Persistence lifecycle hooks now run when entities are loaded and saved.
  * Loading hooks receive the restored entity and saved data after activation.
  * Saving hooks receive the entity and recorded persistence data before submaterials are collected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->